### PR TITLE
feat(dvr): surface a play button on the DVR recordings tables

### DIFF
--- a/app/Filament/GuestPanel/Resources/DvrRecordings/GuestDvrRecordingResource.php
+++ b/app/Filament/GuestPanel/Resources/DvrRecordings/GuestDvrRecordingResource.php
@@ -7,6 +7,7 @@ use App\Filament\GuestPanel\Pages\Concerns\HasGuestDvr;
 use App\Jobs\ProcessComskipOnRecording;
 use App\Jobs\StopDvrRecording;
 use App\Models\DvrRecording;
+use App\Models\PlaylistAuth;
 use App\Tables\Columns\AnimatedStatusColumn;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
@@ -30,6 +31,36 @@ class GuestDvrRecordingResource extends Resource
     protected static ?string $model = DvrRecording::class;
 
     protected static ?string $slug = 'dvr';
+
+    /**
+     * Whether the given guest may play the given recording.
+     *
+     * Single source of truth for the play authorization, deliberately factored
+     * out of the table so it can be asserted directly. The guest panel resolves
+     * its auth from request attributes, and `Livewire::test()` cannot carry
+     * those across synthetic requests (see the note on
+     * setupGuestReleaseDateContext in the guest tests), so the action closures
+     * themselves are not reachable from a test. Keeping the predicate here means
+     * the rule is still covered, and — more importantly — that `visible()` and
+     * the in-action backend guard cannot drift apart, since both call this.
+     */
+    public static function guestCanPlay(DvrRecording $record, ?PlaylistAuth $auth): bool
+    {
+        if (! in_array($record->status, [
+            DvrRecordingStatus::Recording,
+            DvrRecordingStatus::Completed,
+        ], true)) {
+            return false;
+        }
+
+        if (! $record->dvrSetting?->owner()) {
+            return false;
+        }
+
+        // Guests may only play their own recordings. Owner-created recordings
+        // (null playlist_auth_id) are never a guest's to play.
+        return $auth !== null && $record->playlist_auth_id === $auth->id;
+    }
 
     public static function getNavigationLabel(): string
     {
@@ -271,6 +302,29 @@ class GuestDvrRecordingResource extends Resource
                                 ->send();
                         }),
                 ])->button()->hiddenLabel()->size('sm'),
+                Action::make('play')
+                    ->label(__('Watch'))
+                    ->tooltip(__('Watch'))
+                    ->icon('heroicon-s-play-circle')
+                    ->color('success')
+                    ->button()
+                    ->hiddenLabel()
+                    ->size('sm')
+                    ->visible(fn (DvrRecording $record): bool => static::guestCanPlay($record, $currentAuth))
+                    ->action(function (DvrRecording $record, $livewire) use ($currentAuth): void {
+                        // Backend guard — prevents forged Livewire calls bypassing
+                        // ->visible(). Same predicate, deliberately re-evaluated.
+                        if (! static::guestCanPlay($record, $currentAuth)) {
+                            Notification::make()
+                                ->danger()
+                                ->title(__('Unauthorized'))
+                                ->send();
+
+                            return;
+                        }
+
+                        $livewire->dispatch('openFloatingStream', $record->getFloatingPlayerAttributes());
+                    }),
             ], position: RecordActionsPosition::BeforeCells)
             ->toolbarActions([]);
     }

--- a/app/Filament/GuestPanel/Resources/DvrRecordings/GuestDvrRecordingResource.php
+++ b/app/Filament/GuestPanel/Resources/DvrRecordings/GuestDvrRecordingResource.php
@@ -137,7 +137,7 @@ class GuestDvrRecordingResource extends Resource
         }
 
         return parent::getEloquentQuery()
-            ->with(['channel', 'playlistAuth'])
+            ->with(['channel', 'playlistAuth', 'dvrSetting.playlist', 'dvrSetting.customPlaylist', 'dvrSetting.mergedPlaylist'])
             ->where('dvr_setting_id', $dvrSetting->id)
             ->orderByDesc('scheduled_start');
     }

--- a/app/Filament/Resources/DvrRecordings/DvrRecordingResource.php
+++ b/app/Filament/Resources/DvrRecordings/DvrRecordingResource.php
@@ -355,6 +355,7 @@ class DvrRecordingResource extends Resource
                         ->modalDescription(__('Are you sure you want to delete this recording? The file on disk and any linked VOD entry will also be removed.')),
                 ])->button()->hiddenLabel()->size('sm'),
                 Action::make('play')
+                    ->label(__('Watch'))
                     ->tooltip(__('Watch'))
                     ->action(function (DvrRecording $record, $livewire): void {
                         $livewire->dispatch('openFloatingStream', $record->getFloatingPlayerAttributes());

--- a/app/Filament/Resources/DvrRecordings/DvrRecordingResource.php
+++ b/app/Filament/Resources/DvrRecordings/DvrRecordingResource.php
@@ -304,17 +304,6 @@ class DvrRecordingResource extends Resource
             ->recordActions([
                 ActionGroup::make([
                     ViewAction::make(),
-                    Action::make('watch')
-                        ->label(__('Watch'))
-                        ->icon('heroicon-o-play-circle')
-                        ->color('success')
-                        ->visible(fn (DvrRecording $record): bool => in_array($record->status, [
-                            DvrRecordingStatus::Recording,
-                            DvrRecordingStatus::Completed,
-                        ]) && $record->dvrSetting?->owner())
-                        ->action(function (DvrRecording $record, $livewire): void {
-                            $livewire->dispatch('openFloatingStream', $record->getFloatingPlayerAttributes());
-                        }),
                     Action::make('retry')
                         ->label(__('Retry Post-Processing'))
                         ->icon('heroicon-o-arrow-path')
@@ -365,6 +354,20 @@ class DvrRecordingResource extends Resource
                     DeleteAction::make()
                         ->modalDescription(__('Are you sure you want to delete this recording? The file on disk and any linked VOD entry will also be removed.')),
                 ])->button()->hiddenLabel()->size('sm'),
+                Action::make('play')
+                    ->tooltip(__('Watch'))
+                    ->action(function (DvrRecording $record, $livewire): void {
+                        $livewire->dispatch('openFloatingStream', $record->getFloatingPlayerAttributes());
+                    })
+                    ->icon('heroicon-s-play-circle')
+                    ->color('success')
+                    ->visible(fn (DvrRecording $record): bool => in_array($record->status, [
+                        DvrRecordingStatus::Recording,
+                        DvrRecordingStatus::Completed,
+                    ]) && $record->dvrSetting?->owner())
+                    ->button()
+                    ->hiddenLabel()
+                    ->size('sm'),
             ], position: RecordActionsPosition::BeforeCells)
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/tests/Feature/DvrRecordingResourceTableTest.php
+++ b/tests/Feature/DvrRecordingResourceTableTest.php
@@ -9,6 +9,7 @@ use App\Models\DvrSetting;
 use App\Models\Playlist;
 use App\Models\PlaylistAuth;
 use App\Models\User;
+use Filament\Actions\Testing\TestAction;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
 use Livewire\Livewire;
@@ -301,4 +302,83 @@ it('filters recordings by guest playlist_auth_id', function () {
         ->filterTable('playlist_auth_id', $authA->id)
         ->assertCanSeeTableRecords([$aliceRecording])
         ->assertCanNotSeeTableRecords([$bobRecording]);
+});
+
+it('shows the play action for a completed recording with an owner', function () {
+    $recording = DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->dvrSetting)
+        ->completed()
+        ->create([
+            'title' => 'Completed Playable',
+        ]);
+
+    Livewire::test(ListDvrRecordings::class)
+        ->assertOk()
+        ->loadTable()
+        ->assertActionVisible(TestAction::make('play')->table($recording));
+});
+
+it('shows the play action for a recording-in-progress', function () {
+    $recording = DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->dvrSetting)
+        ->recording()
+        ->create([
+            'title' => 'Live Recording',
+        ]);
+
+    Livewire::test(ListDvrRecordings::class)
+        ->assertOk()
+        ->loadTable()
+        ->assertActionVisible(TestAction::make('play')->table($recording));
+});
+
+it('hides the play action for a scheduled recording', function () {
+    $recording = DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->dvrSetting)
+        ->create([
+            'status' => DvrRecordingStatus::Scheduled,
+            'title' => 'Scheduled Recording',
+        ]);
+
+    Livewire::test(ListDvrRecordings::class)
+        ->assertOk()
+        ->loadTable()
+        ->assertActionHidden(TestAction::make('play')->table($recording));
+});
+
+it('hides the play action for a failed recording', function () {
+    $recording = DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->dvrSetting)
+        ->failed()
+        ->create([
+            'title' => 'Failed Recording',
+        ]);
+
+    Livewire::test(ListDvrRecordings::class)
+        ->assertOk()
+        ->loadTable()
+        ->assertActionHidden(TestAction::make('play')->table($recording));
+});
+
+it('hides the play action when the dvr setting has no owner', function () {
+    $orphanSetting = DvrSetting::factory()
+        ->for($this->user)
+        ->create(['playlist_id' => null]);
+
+    $recording = DvrRecording::factory()
+        ->for($this->user)
+        ->for($orphanSetting)
+        ->completed()
+        ->create([
+            'title' => 'Orphaned Completed Recording',
+        ]);
+
+    Livewire::test(ListDvrRecordings::class)
+        ->assertOk()
+        ->loadTable()
+        ->assertActionHidden(TestAction::make('play')->table($recording));
 });

--- a/tests/Feature/GuestDvrRecordingResourceTest.php
+++ b/tests/Feature/GuestDvrRecordingResourceTest.php
@@ -206,3 +206,82 @@ it('cancel guard accepts recordings in Recording status', function () {
     expect($isOwner)->toBeTrue()
         ->and($isCancellable)->toBeTrue();
 });
+
+// --- Play action visibility (visible() closure predicates) ---
+
+/*
+ * Play authorization (#1366).
+ *
+ * These assert GuestDvrRecordingResource::guestCanPlay() directly, which is the
+ * single predicate both ->visible() and the in-action backend guard call. The
+ * guest panel resolves its auth from request attributes and Livewire::test()
+ * cannot carry those across synthetic requests (see the note on
+ * setupGuestReleaseDateContext), so the action closures are not reachable from a
+ * test — asserting the shared predicate is what keeps the rule covered, and
+ * stops the two layers drifting apart.
+ */
+
+function makeGuestPlayRecording(object $ctx, DvrRecordingStatus $status, ?int $authId): DvrRecording
+{
+    return DvrRecording::factory()
+        ->for($ctx->dvrSetting)
+        ->for($ctx->user)
+        ->create(['playlist_auth_id' => $authId, 'status' => $status]);
+}
+
+it('guestCanPlay allows an owned Completed recording', function () {
+    $record = makeGuestPlayRecording($this, DvrRecordingStatus::Completed, $this->guestA->id);
+
+    expect(GuestDvrRecordingResource::guestCanPlay($record, $this->guestA))->toBeTrue();
+});
+
+it('guestCanPlay allows an owned in-progress recording', function () {
+    $record = makeGuestPlayRecording($this, DvrRecordingStatus::Recording, $this->guestA->id);
+
+    expect(GuestDvrRecordingResource::guestCanPlay($record, $this->guestA))->toBeTrue();
+});
+
+it('guestCanPlay REFUSES a recording owned by a different guest', function () {
+    // The security case: guest A must never play guest B's recording.
+    $record = makeGuestPlayRecording($this, DvrRecordingStatus::Completed, $this->guestB->id);
+
+    expect(GuestDvrRecordingResource::guestCanPlay($record, $this->guestA))->toBeFalse();
+});
+
+it('guestCanPlay REFUSES an owner-created recording (null playlist_auth_id)', function () {
+    $record = makeGuestPlayRecording($this, DvrRecordingStatus::Completed, null);
+
+    expect(GuestDvrRecordingResource::guestCanPlay($record, $this->guestA))->toBeFalse();
+});
+
+it('guestCanPlay REFUSES when there is no authenticated guest', function () {
+    $record = makeGuestPlayRecording($this, DvrRecordingStatus::Completed, $this->guestA->id);
+
+    expect(GuestDvrRecordingResource::guestCanPlay($record, null))->toBeFalse();
+});
+
+it('guestCanPlay REFUSES a Scheduled recording even when owned', function () {
+    $record = makeGuestPlayRecording($this, DvrRecordingStatus::Scheduled, $this->guestA->id);
+
+    expect(GuestDvrRecordingResource::guestCanPlay($record, $this->guestA))->toBeFalse();
+});
+
+it('guestCanPlay REFUSES a Failed recording even when owned', function () {
+    $record = makeGuestPlayRecording($this, DvrRecordingStatus::Failed, $this->guestA->id);
+
+    expect(GuestDvrRecordingResource::guestCanPlay($record, $this->guestA))->toBeFalse();
+});
+
+it('guestCanPlay REFUSES when the DvrSetting has no resolvable owner', function () {
+    $orphanSetting = DvrSetting::factory()->enabled()->for($this->user)->create([
+        'playlist_id' => null,
+        'custom_playlist_id' => null,
+        'merged_playlist_id' => null,
+    ]);
+    $record = DvrRecording::factory()
+        ->for($orphanSetting)
+        ->for($this->user)
+        ->create(['playlist_auth_id' => $this->guestA->id, 'status' => DvrRecordingStatus::Completed]);
+
+    expect(GuestDvrRecordingResource::guestCanPlay($record, $this->guestA))->toBeFalse();
+});


### PR DESCRIPTION
Closes #1366.

## Summary
The play affordance already existed on the **admin** DVR table, but it was buried inside the `...` `ActionGroup` — which is exactly why it looked missing. The **guest** panel had none at all. Both tables now render it as an icon button immediately right of the `...` menu, matching the live channel list the issue points at.

- **Admin** (`DvrRecordingResource`): the dropdown `watch` item is replaced by a sibling `play` action.
- **Guest** (`GuestDvrRecordingResource`): a play action is added. That panel is credential-scoped, so it is authorized on two layers — `->visible()` **and** a backend guard inside the action closure. A hidden button is not access control; a forged Livewire call can still reach the action. This mirrors the existing `cancel` action's pattern in the same file.

## `guestCanPlay()` — why the predicate is factored out
Both guest layers call one new `public static guestCanPlay(DvrRecording, ?PlaylistAuth): bool`. Two reasons, and the second is the important one:

1. The layers previously duplicated the ownership expression independently and could drift apart.
2. **The action closures are not reachable from a test.** The guest panel resolves its auth from request attributes, and `Livewire::test()` cannot carry those across synthetic requests — this is already documented in the repo's own guest test helpers. A shared predicate is therefore the only part of that logic that *can* be asserted.

That second point was not theoretical. The guest play tests, written in the file's existing style, re-derived the ownership expression in the test body and asserted it. I verified that they **passed with the backend guard deleted entirely**. They now exercise `guestCanPlay()` directly, and removing the ownership check fails three of them.

⚠️ **The pre-existing `cancel guard` tests in the same file share that original shape** and would also pass with their guard removed. Out of scope here, but worth a follow-up — it's false confidence on a security-critical path, and the `guestCanPlay()` pattern is a template for fixing it.

## Consistency across the two surfaces
Both deliberately identical, since they'd otherwise diverge:
- **Icon**: solid `heroicon-s-play-circle` — reads better at icon-button size and matches the channel/VOD precedent for always-visible primary play buttons. (The old dropdown item used the outline variant, which was an artifact of being a dropdown item.)
- **Ordering**: placed *after* the `ActionGroup`, so with `RecordActionsPosition::BeforeCells` it renders to the group's right — where the issue asks for it.
- **Label**: reuses the existing `__('Watch')` key, already present in all five locales. No new translation work.

## Visibility rules
Shown only for `Recording` / `Completed` status, and only when `$record->dvrSetting?->owner()` resolves. On the guest panel, additionally only for recordings whose `playlist_auth_id` matches the current guest — owner-created recordings (`playlist_auth_id` null) are never a guest's to play, consistent with `cancel`.

## Test plan
- [x] `DvrRecordingResourceTableTest` — 5 new cases (visible for Completed and for in-progress; hidden for Scheduled, for Failed, and when the DvrSetting has no owner). **14 pass.**
- [x] `GuestDvrRecordingResourceTest` — 8 cases against `guestCanPlay()`, including the security case (a recording owned by a *different* guest) and the no-authenticated-guest case. **23 pass.**
- [x] **Mutation-checked both halves.** Stripping the admin `->visible()` guard fails exactly the 3 hide-cases. Replacing the guest ownership check with `return true` fails exactly 3 tests. Both restored.
- [x] `vendor/bin/pint` clean on all four touched files.
- [x] **Full suite: 3131 passed, 32 skipped, 0 failed.**