### PR TITLE
fix(dvr): re-broadcast status once VOD integration actually finishes

### DIFF
--- a/app/Jobs/IntegrateDvrRecordingToVod.php
+++ b/app/Jobs/IntegrateDvrRecordingToVod.php
@@ -50,6 +50,15 @@ class IntegrateDvrRecordingToVod implements ShouldQueue
         // Clear the step label now that the full pipeline is done
         $recording->update(['post_processing_step' => null]);
 
+        // Re-broadcast the current status so connected TV clients know the
+        // library entry now exists. The completion broadcast fired from
+        // DvrPostProcessorService goes out the instant status flips to
+        // Completed, *before* this queued job has a chance to create the
+        // Series/Episode/Channel rows — so without this second push, clients
+        // refreshed on the first push and saw nothing. broadcastStatus() is
+        // safe to call with an unchanged status (issue #1403).
+        $recording->broadcastStatus();
+
         Log::info("DVR VOD integration complete for recording {$recording->id}", [
             'recording_id' => $recording->id,
         ]);

--- a/tests/Feature/DvrVodIntegrationServiceTest.php
+++ b/tests/Feature/DvrVodIntegrationServiceTest.php
@@ -19,6 +19,7 @@
  */
 
 use App\Enums\DvrRecordingStatus;
+use App\Events\DvrRecordingStatusEvent;
 use App\Jobs\EnrichDvrMetadata;
 use App\Jobs\IntegrateDvrRecordingToVod;
 use App\Models\Channel;
@@ -37,6 +38,7 @@ use App\Services\DvrVodIntegrationService;
 use Carbon\Carbon;
 use Filament\Notifications\DatabaseNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
@@ -1187,4 +1189,136 @@ it('skips gracefully when setting has no playlist_id and channel has no playlist
     expect(fn () => $this->service->integrateRecording($recording))->not->toThrow(Exception::class);
     expect(Episode::where('dvr_recording_id', $recording->id)->exists())->toBeFalse();
     expect(Channel::where('dvr_recording_id', $recording->id)->exists())->toBeFalse();
+});
+
+// ── Issue #1403: re-broadcast status when VOD integration actually finishes ───
+//
+// DvrPostProcessorService::process() flips status -> Completed (which
+// auto-broadcasts via DvrRecording's updated hook) and only then dispatches
+// IntegrateDvrRecordingToVod onto the dvr-post queue. Without a second
+// broadcast at the end of the job, clients refresh on the first (premature)
+// push and never receive a refresh signal that lands after the Series /
+// Episode / Channel rows actually exist.
+//
+// These tests pin the behavior of the fix (single broadcast at end of
+// successful handle(), no broadcast on genuine throw, no-spurious-broadcast
+// on the skip path).
+
+it('re-broadcasts status exactly once at the end of a successful handle() — issue #1403', function () {
+    $recording = makeCompletedRecording([
+        'title' => 'Inception',
+        'season' => null,
+        'episode' => null,
+        'metadata' => [
+            'tmdb' => [
+                'id' => 27205,
+                'type' => 'movie',
+                'name' => 'Inception',
+                'overview' => 'A thief who steals corporate secrets.',
+                'poster_url' => 'https://image.tmdb.org/t/p/w500/poster.jpg',
+                'release_date' => '2010-07-16',
+            ],
+        ],
+    ]);
+
+    // Event::fake() is installed AFTER the recording was created above, so
+    // the factory-driven created-hook broadcast at create-time is not in
+    // scope — we are only asserting broadcasts that fire from inside
+    // handle().
+    Event::fake([DvrRecordingStatusEvent::class]);
+
+    (new IntegrateDvrRecordingToVod($recording->id))->handle($this->service);
+
+    Event::assertDispatchedTimes(DvrRecordingStatusEvent::class, 1);
+    Event::assertDispatched(
+        DvrRecordingStatusEvent::class,
+        fn (DvrRecordingStatusEvent $event) => $event->uuid === $recording->uuid
+            && $event->status === 'completed'
+            && $event->title === 'Inception'
+    );
+
+    // Sanity: the integration itself still ran — Channel row exists.
+    expect(Channel::where('dvr_recording_id', $recording->id)->exists())->toBeTrue();
+});
+
+it('does not re-broadcast when integrateRecording() throws — retry semantics preserved — issue #1403', function () {
+    $recording = makeCompletedRecording([
+        'title' => 'Failing Movie',
+        'season' => null,
+        'episode' => null,
+        'metadata' => [
+            'tmdb' => ['id' => 999, 'type' => 'movie', 'name' => 'Failing Movie'],
+        ],
+    ]);
+
+    // Stub the integration service to throw — matches the real behaviour of
+    // DvrVodIntegrationService::integrateRecording()'s catch block, which
+    // rethrows.
+    $failingService = Mockery::mock(DvrVodIntegrationService::class);
+    $failingService->shouldReceive('integrateRecording')
+        ->once()
+        ->andThrow(new Exception('integration failed'));
+
+    Event::fake([DvrRecordingStatusEvent::class]);
+
+    expect(fn () => (new IntegrateDvrRecordingToVod($recording->id))->handle($failingService))
+        ->toThrow(Exception::class, 'integration failed');
+
+    // Critical: no second broadcast fires when integration genuinely fails.
+    // The job's `tries = 3` retry path is the only path that should retry —
+    // a spurious broadcast here would falsely tell clients the library row
+    // exists when it doesn't.
+    Event::assertNotDispatched(DvrRecordingStatusEvent::class);
+});
+
+it('completes handle() without error on the no-resolvable-playlist skip path — issue #1403', function () {
+    // Orphaned-recording scenario (same shape as the
+    // "skips gracefully when setting has no playlist_id and channel has no
+    //  playlist_id" test above, but exercised at the JOB level).  This is
+    // the only DB-constructible skip path now that user_id and
+    // dvr_setting_id are NOT NULL — they would also early-return from
+    // integrateRecording(), but cannot be reproduced in tests.
+    $user = User::factory()->create();
+    $setting = DvrSetting::factory()->enabled()->for($user)->create([
+        'playlist_id' => null,
+        'merged_playlist_id' => null,
+        'custom_playlist_id' => null,
+    ]);
+    $channel = Channel::factory()->for($user)->create(['playlist_id' => null]);
+
+    $recording = DvrRecording::factory()
+        ->completed()
+        ->for($setting, 'dvrSetting')
+        ->for($user)
+        ->for($channel, 'channel')
+        ->create([
+            'title' => 'Orphan Recording',
+            'season' => 1,
+            'episode' => 1,
+            'metadata' => null,
+        ]);
+
+    Event::fake([DvrRecordingStatusEvent::class]);
+
+    // Critical assertion: handle() reaches its end without throwing even
+    // when integrateRecording() early-returns.  The fix's
+    // broadcastStatus() call must NOT be guarded on "did integration
+    // actually do something?", per the issue.
+    expect(fn () => (new IntegrateDvrRecordingToVod($recording->id))->handle($this->service))
+        ->not->toThrow(Exception::class);
+
+    // For an orphaned recording (no resolvable playlist), the recording's
+    // owner() is null and broadcastStatus() silently no-ops — no event is
+    // dispatched, because there is no Reverb channel for a player to
+    // subscribe to. The fix preserves this safety: the broadcast call is
+    // reached (no exception interrupts it), and the no-op result is the
+    // correct safety outcome.
+    Event::assertNotDispatched(DvrRecordingStatusEvent::class);
+
+    // Confirm we did reach the broadcastStatus() call (not just that
+    // handle() bailed out earlier) by verifying the post_processing_step
+    // label was cleared. handle() clears it on the success and skip paths
+    // both; only an uncaught throw would leave it set.
+    $recording->refresh();
+    expect($recording->post_processing_step)->toBeNull();
 });


### PR DESCRIPTION
Closes #1403

## Problem

A completed recording's status push goes out before the library rows it announces actually exist.

`DvrPostProcessorService::process()` dispatches the VOD integration job (`IntegrateDvrRecordingToVod`, either directly or via `EnrichDvrMetadata` when metadata enrichment is enabled) onto a queue — fire-and-forget, no wait — then immediately flips `status` to `Completed`. `DvrRecording`'s `updated` hook auto-broadcasts on any status change, so the push goes out the instant that happens.

A connected client (e.g. m3u-tv) refreshes its library on that push and finds nothing new, because the queued job hasn't created the `Series`/`Episode`/`Channel` rows yet. No second push ever arrives once it does, since `status` doesn't change again — only a manual client refresh, issued after the queue caught up, finds the content.

Full root-cause trace with file:line citations is in #1403.

## Fix

One line at the end of `IntegrateDvrRecordingToVod::handle()`:

```php
$recording->broadcastStatus();
```

Re-announces the same (unchanged) status once the library rows genuinely exist. `broadcastStatus()` is a plain rebuild-and-broadcast, safe to call a second time.

**No client-side change needed.** m3u-tv's push handler re-fetches and re-classifies unconditionally on every push it receives, with no comparison against a previously-seen status — so the second push naturally triggers the refresh the first one couldn't.

Deliberately not gated on whether integration actually did anything:
- The #1395/#1396 early-return paths (no resolvable playlist, no user) still reach this line and produce a redundant no-op broadcast. Matches the "over-refresh, never under-refresh" precedent already established client-side for this exact feature.
- A thrown exception in `integrateRecording()` means `handle()` never reaches this line at all — no spurious broadcast on genuine failure, the job's existing `tries = 3` retry is unaffected.

Alternatives considered and rejected (detailed in #1403): delaying the `Completed` status flip itself (breaks the "Watch" button and notification, which are legitimately ready earlier), and a new distinct event type for "library updated" (needs a coordinated client change for no benefit over reusing the existing push).

## Test plan

- 3 new cases in `tests/Feature/DvrVodIntegrationServiceTest.php`:
  - re-broadcasts exactly once on a successful `handle()`
  - does **not** re-broadcast when `integrateRecording()` throws — retry semantics preserved
  - completes `handle()` without error on the no-resolvable-playlist skip path. (`broadcastStatus()` itself no-ops there — `DvrRecordingStatusEvent`'s own `owner()` guard returns null with nothing to key a Reverb channel on, not new behaviour from this fix.)
- `vendor/bin/pint --dirty --test` → passed
- `vendor/bin/pest tests/Feature/DvrVodIntegrationServiceTest.php` → 47 passed (128 assertions) — 44 pre-existing + 3 new
- **Mutation-checked**: reverting the fix fails exactly the "fires once" case (`assertDispatchedTimes` 0 vs 1); the throw-path and skip-path cases are unaffected, as expected since neither reaches the fix's line either way. Restored, 47/47 green.
- Full `php artisan test`: not chased further. All 762 failures in this worktree's environment are `ConnectionException` against a Redis port this worktree's environment never started, spanning domains with no plausible interaction with this change (AIOStreams, EDL endpoints, Xtream network fallback, regex tester).