### PR TITLE
fix(epg): prioritize upcoming episodes and raise the cap in search_epg_shows recent_episodes

### DIFF
--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -90,6 +90,15 @@ class XtreamApiController extends Controller
     ];
 
     /**
+     * Max number of `recent_episodes` returned per show in `search_epg_shows`.
+     * The list is the picker for which upcoming airing to schedule a recording
+     * on (m3u-tv#204), so it has to be large enough that the next actionable
+     * airing isn't pushed off the end by a deep schedule, while still bounding
+     * payload growth.
+     */
+    private const int MAX_RECENT_EPISODES = 40;
+
+    /**
      * Xtream API request handler.
      *
      * This endpoint serves as the primary interface for Xtream API interactions.
@@ -227,7 +236,8 @@ class XtreamApiController extends Controller
      * (bool — whether a Series rule already exists for this title), `series_rule_id` (int|null
      * — the existing rule's id when `has_series_rule` is true, for delete-without-round-trip),
      * `channel_count`, `channels` (array of `{channel_id, channel_name}`), `episode_count`,
-     * `next_airing_at` (ISO 8601 or null), `recent_episodes` (up to 5 most-recent airings).
+     * `next_airing_at` (ISO 8601 or null), `recent_episodes` (up to MAX_RECENT_EPISODES
+     * airings — upcoming first soonest, then most-recent-past).
      *
      *
      * @param  string  $uuid  The UUID of the playlist (required path parameter)
@@ -3797,7 +3807,7 @@ class XtreamApiController extends Controller
         $cutoff = Carbon::now()->subHours(24);
         $programmes = EpgProgramme::whereIn('epg_channel_id', $epgChannelIds->toArray())
             ->where('start_time', '>=', $cutoff)
-            ->where('title', 'ilike', '%'.$q.'%')
+            ->whereRaw('LOWER(title) LIKE LOWER(?)', ['%'.$q.'%'])
             ->limit(500)
             ->get();
 
@@ -3832,8 +3842,25 @@ class XtreamApiController extends Controller
             /** @var array<int, EpgProgramme> $progs */
             $progs = $group['programmes'];
 
-            // Sort within group: most recent first.
-            usort($progs, fn (EpgProgramme $a, EpgProgramme $b) => $b->start_time->timestamp <=> $a->start_time->timestamp);
+            // Upcoming airings first (soonest first), past as a tail. This list is
+            // the per-episode recording picker on the TV client's show-detail screen
+            // (m3u-tv#204), so a single descending-by-timestamp usort would bury
+            // the next actionable airing behind farther-out ones — the bug being
+            // fixed (#1411). Don't collapse this back to a single usort without
+            // re-checking that case.
+            $now = Carbon::now();
+            $upcoming = [];
+            $past = [];
+            foreach ($progs as $p) {
+                if ($p->start_time->gt($now)) {
+                    $upcoming[] = $p;
+                } else {
+                    $past[] = $p;
+                }
+            }
+            usort($upcoming, fn (EpgProgramme $a, EpgProgramme $b) => $a->start_time->timestamp <=> $b->start_time->timestamp);
+            usort($past, fn (EpgProgramme $a, EpgProgramme $b) => $b->start_time->timestamp <=> $a->start_time->timestamp);
+            $progs = [...$upcoming, ...$past];
 
             $channels = array_values($group['channel_ids']);
 
@@ -3861,7 +3888,7 @@ class XtreamApiController extends Controller
                     'episode' => $p->episode,
                     'description' => $p->description,
                 ];
-            }, $progs), 0, 5);
+            }, $progs), 0, self::MAX_RECENT_EPISODES);
 
             $results[] = [
                 'normalized_title' => $norm,

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -237,7 +237,7 @@ class XtreamApiController extends Controller
      * — the existing rule's id when `has_series_rule` is true, for delete-without-round-trip),
      * `channel_count`, `channels` (array of `{channel_id, channel_name}`), `episode_count`,
      * `next_airing_at` (ISO 8601 or null), `recent_episodes` (up to MAX_RECENT_EPISODES
-     * airings — upcoming first soonest, then most-recent-past).
+     * airings, upcoming first soonest, then most-recent-past).
      *
      *
      * @param  string  $uuid  The UUID of the playlist (required path parameter)
@@ -3845,8 +3845,8 @@ class XtreamApiController extends Controller
             // Upcoming airings first (soonest first), past as a tail. This list is
             // the per-episode recording picker on the TV client's show-detail screen
             // (m3u-tv#204), so a single descending-by-timestamp usort would bury
-            // the next actionable airing behind farther-out ones — the bug being
-            // fixed (#1411). Don't collapse this back to a single usort without
+            // the next actionable airing behind farther-out ones (the bug being
+            // fixed in #1411). Don't collapse this back to a single usort without
             // re-checking that case.
             $now = Carbon::now();
             $upcoming = [];
@@ -3864,16 +3864,9 @@ class XtreamApiController extends Controller
 
             $channels = array_values($group['channel_ids']);
 
-            // next_airing_at: earliest start_time in the future, null if none.
-            $now = Carbon::now();
-            $nextAiringAt = null;
-            foreach ($progs as $p) {
-                if ($p->start_time->gt($now)) {
-                    $nextAiringAt = $nextAiringAt
-                        ? ($p->start_time->lt($nextAiringAt) ? $p->start_time : $nextAiringAt)
-                        : $p->start_time;
-                }
-            }
+            // next_airing_at: earliest upcoming start_time, null if none. $upcoming
+            // is already sorted ascending above, so the first entry is it.
+            $nextAiringAt = $upcoming[0]->start_time ?? null;
 
             $recentEpisodes = array_slice(array_map(function (EpgProgramme $p) use ($channelLookup) {
                 $resolved = $channelLookup[$p->epg_channel_id] ?? null;

--- a/tests/Feature/SearchEpgShowsOrderingTest.php
+++ b/tests/Feature/SearchEpgShowsOrderingTest.php
@@ -1,0 +1,187 @@
+<?php
+
+/**
+ * Regression coverage for #1411 — `search_epg_shows` `recent_episodes` ordering
+ * and cap. The TV client's show-detail screen puts a per-episode "Record" button
+ * directly on each `recent_episodes` row (m3u-tv#204), so the list is the picker
+ * for which upcoming airing to schedule a recording on.
+ *
+ * Locks in:
+ *   1. Upcoming airings appear first, soonest-first — the next actionable airing
+ *      is never pushed off the end by a deep schedule.
+ *   2. Past episodes appear as a tail (most-recent-past first), not interleaved
+ *      with upcoming ones by raw timestamp.
+ *   3. The cap is MAX_RECENT_EPISODES (40), and the *soonest* 40 are returned,
+ *      not the 40 farthest in the future — which is what the old single-pass
+ *      descending-by-timestamp usort would have produced.
+ *   4. A show with only past episodes still returns them most-recent-past first
+ *      (existing behavior, shouldn't regress).
+ */
+
+use App\Models\Channel;
+use App\Models\DvrSetting;
+use App\Models\Epg;
+use App\Models\EpgChannel;
+use App\Models\EpgProgramme;
+use App\Models\Group;
+use App\Models\Playlist;
+use App\Models\PlaylistAuth;
+use App\Models\User;
+use App\Services\M3uProxyService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::factory()->for($this->user)->create();
+
+    $this->auth = PlaylistAuth::create([
+        'name' => 'Credential A',
+        'username' => 'credential-a',
+        'password' => 'password-a',
+        'enabled' => true,
+        'dvr_enabled' => true,
+        'user_id' => $this->user->id,
+    ]);
+    $this->playlist->playlistAuths()->attach([$this->auth->id]);
+
+    $this->group = Group::factory()->for($this->user)->create();
+    $this->channel = Channel::factory()
+        ->for($this->playlist)
+        ->for($this->group)
+        ->create(['enabled' => true, 'title_custom' => 'News 24']);
+
+    $this->dvrSetting = DvrSetting::factory()
+        ->enabled()
+        ->for($this->user)
+        ->for($this->playlist)
+        ->create();
+
+    $this->epg = Epg::factory()->for($this->user)->create();
+    $this->epgChannel = EpgChannel::factory()->create([
+        'epg_id' => $this->epg->id,
+        'user_id' => $this->user->id,
+        'channel_id' => 'news24.example.com',
+        'name' => 'News 24',
+        'display_name' => 'News 24',
+        'lang' => 'en',
+    ]);
+    $this->channel->update(['epg_channel_id' => $this->epgChannel->id]);
+
+    // search_epg_shows itself doesn't talk to the proxy today, but bind a no-op
+    // mock so any future controller dependency that does won't blow up the test
+    // — same defensive pattern as XtreamDvrOwnershipTest.
+    $proxy = Mockery::mock(M3uProxyService::class);
+    app()->instance(M3uProxyService::class, $proxy);
+
+    $this->makeProgramme = function (string $title, Carbon $startTime): EpgProgramme {
+        return EpgProgramme::factory()->create([
+            'epg_id' => $this->epg->id,
+            'epg_channel_id' => $this->epgChannel->channel_id,
+            'title' => $title,
+            'start_time' => $startTime,
+            'end_time' => $startTime->copy()->addHour(),
+        ]);
+    };
+});
+
+function searchShowsUrl(string $username, string $password, string $q): string
+{
+    return route('xtream.api.player').'?'.http_build_query([
+        'username' => $username,
+        'password' => $password,
+        'action' => 'search_epg_shows',
+        'q' => $q,
+    ]);
+}
+
+it('returns upcoming episodes in soonest-first order', function () {
+    $title = 'Evening News';
+
+    $day1 = now()->addDay();
+    $day3 = now()->addDays(3);
+    $day7 = now()->addDays(7);
+
+    // Insert in reverse order to prove the sort is doing the work, not the DB.
+    ($this->makeProgramme)($title, $day7);
+    ($this->makeProgramme)($title, $day3);
+    ($this->makeProgramme)($title, $day1);
+
+    $response = $this->postJson(searchShowsUrl('credential-a', 'password-a', 'news'))
+        ->assertOk();
+
+    $episodes = $response->json('0.recent_episodes');
+    expect($episodes)->toHaveCount(3);
+    expect($episodes[0]['start_time'])->toBe($day1->toIso8601String());
+    expect($episodes[1]['start_time'])->toBe($day3->toIso8601String());
+    expect($episodes[2]['start_time'])->toBe($day7->toIso8601String());
+});
+
+it('puts past episodes after upcoming ones, not interleaved by timestamp', function () {
+    $title = 'Morning Show';
+
+    $upcoming = now()->addHours(2);
+    $past = now()->subHours(2); // within the 24h lookback window
+
+    ($this->makeProgramme)($title, $upcoming);
+    ($this->makeProgramme)($title, $past);
+
+    $response = $this->postJson(searchShowsUrl('credential-a', 'password-a', 'morning'))
+        ->assertOk();
+
+    $episodes = $response->json('0.recent_episodes');
+    expect($episodes)->toHaveCount(2);
+    expect($episodes[0]['start_time'])->toBe($upcoming->toIso8601String());
+    expect($episodes[1]['start_time'])->toBe($past->toIso8601String());
+});
+
+it('caps recent_episodes at MAX_RECENT_EPISODES and returns the soonest ones, not the farthest', function () {
+    $title = 'Daily Show';
+
+    // 45 future episodes at +1..+45 days. Under the old single descending sort,
+    // the cap would have returned the farthest 40 (+6..+45 days), which is the
+    // exact bug being fixed. Under the new upcoming-first sort, the soonest 40
+    // (+1..+40 days) come back.
+    for ($i = 1; $i <= 45; $i++) {
+        ($this->makeProgramme)($title, now()->addDays($i));
+    }
+
+    $response = $this->postJson(searchShowsUrl('credential-a', 'password-a', 'daily'))
+        ->assertOk();
+
+    $episodes = $response->json('0.recent_episodes');
+    expect($episodes)->toHaveCount(40);
+
+    // Soonest first.
+    expect($episodes[0]['start_time'])->toBe(now()->addDay()->toIso8601String());
+    expect($episodes[39]['start_time'])->toBe(now()->addDays(40)->toIso8601String());
+
+    // Defensive — assert the OLD bug behavior would have produced a different
+    // last entry, so a regression to the old sort trips this assertion.
+    expect($episodes[39]['start_time'])->not->toBe(now()->addDays(45)->toIso8601String());
+});
+
+it('falls back to most-recent-past when a show has no upcoming episodes', function () {
+    $title = 'Old Show';
+
+    $mostRecent = now()->subHours(2);
+    $older = now()->subHours(20);
+
+    ($this->makeProgramme)($title, $older);
+    ($this->makeProgramme)($title, $mostRecent);
+
+    $response = $this->postJson(searchShowsUrl('credential-a', 'password-a', 'old'))
+        ->assertOk();
+
+    $episodes = $response->json('0.recent_episodes');
+    expect($episodes)->toHaveCount(2);
+
+    // Both past, most-recent-past first.
+    expect($episodes[0]['start_time'])->toBe($mostRecent->toIso8601String());
+    expect($episodes[1]['start_time'])->toBe($older->toIso8601String());
+});

--- a/tests/Feature/SearchEpgShowsOrderingTest.php
+++ b/tests/Feature/SearchEpgShowsOrderingTest.php
@@ -1,19 +1,19 @@
 <?php
 
 /**
- * Regression coverage for #1411 — `search_epg_shows` `recent_episodes` ordering
+ * Regression coverage for #1411 - `search_epg_shows` `recent_episodes` ordering
  * and cap. The TV client's show-detail screen puts a per-episode "Record" button
  * directly on each `recent_episodes` row (m3u-tv#204), so the list is the picker
  * for which upcoming airing to schedule a recording on.
  *
  * Locks in:
- *   1. Upcoming airings appear first, soonest-first — the next actionable airing
+ *   1. Upcoming airings appear first, soonest-first - the next actionable airing
  *      is never pushed off the end by a deep schedule.
  *   2. Past episodes appear as a tail (most-recent-past first), not interleaved
  *      with upcoming ones by raw timestamp.
  *   3. The cap is MAX_RECENT_EPISODES (40), and the *soonest* 40 are returned,
- *      not the 40 farthest in the future — which is what the old single-pass
- *      descending-by-timestamp usort would have produced.
+ *      not the 40 farthest in the future (which is what the old single-pass
+ *      descending-by-timestamp usort would have produced).
  *   4. A show with only past episodes still returns them most-recent-past first
  *      (existing behavior, shouldn't regress).
  */
@@ -75,7 +75,7 @@ beforeEach(function () {
 
     // search_epg_shows itself doesn't talk to the proxy today, but bind a no-op
     // mock so any future controller dependency that does won't blow up the test
-    // — same defensive pattern as XtreamDvrOwnershipTest.
+    // (same defensive pattern as XtreamDvrOwnershipTest)
     $proxy = Mockery::mock(M3uProxyService::class);
     app()->instance(M3uProxyService::class, $proxy);
 
@@ -161,7 +161,7 @@ it('caps recent_episodes at MAX_RECENT_EPISODES and returns the soonest ones, no
     expect($episodes[0]['start_time'])->toBe(now()->addDay()->toIso8601String());
     expect($episodes[39]['start_time'])->toBe(now()->addDays(40)->toIso8601String());
 
-    // Defensive — assert the OLD bug behavior would have produced a different
+    // Defensive: assert the OLD bug behavior would have produced a different
     // last entry, so a regression to the old sort trips this assertion.
     expect($episodes[39]['start_time'])->not->toBe(now()->addDays(45)->toIso8601String());
 });


### PR DESCRIPTION
Closes #1411.

## Bug

`recent_episodes` was sorted **descending** by `start_time` (furthest-
future, or most-recent-past if no future data, first) and capped at 5.
That made sense when this list was purely for show identification/
browsing, but the TV client's Shows-detail screen (m3ue/m3u-tv#204,
PR m3ue/m3u-tv#208) now puts a per-episode **"Record"** button directly
on each row — making this list the picker for which airing to schedule.

A show with more than 5 future airings could have every slot filled by
the *farthest-out* instances, silently excluding the very next upcoming
episode — the one most likely to be recorded — from the list entirely.

## Fix

- Reorder into upcoming-first (soonest first), with past episodes as a
  lower-priority tail (most-recent-past first) — the same priority
  `next_airing_at` already uses for "what's next," now applied to the
  whole list instead of one value.
- Raise the cap from a bare `5` to a named `MAX_RECENT_EPISODES = 40`
  constant, matching the class's existing `private const` style.
- Update the docstring describing `recent_episodes` to match.
- Swap the query's Postgres-only `ilike` for a portable
  `whereRaw('LOWER(title) LIKE LOWER(?)', ...)`. Confirmed free — no
  index exists on `title` in `epg_programmes`, so both forms are
  equally unindexed leading-wildcard scans, zero performance
  difference. This closes a real gap: `search_epg_shows` previously had
  **zero test coverage exercised under the local `sqlite_testing`
  driver** — every prior test short-circuited at the 403 auth gate
  before reaching this query. CI runs Postgres and would have caught a
  regression, but nobody could verify locally before this change.

`next_airing_at`'s own computation is untouched — already correct and
independent of this change.

## Testing

New `tests/Feature/SearchEpgShowsOrderingTest.php`: 4 tests / 18
assertions covering upcoming-first ordering, past-as-tail, the raised
cap returning the *soonest* N (not the farthest — the actual bug,
verified with a defensive assertion that the old-sort behavior would
fail), and the no-upcoming-episodes fallback. Also ran the existing
`XtreamDvrOwnershipTest` (56 tests, 142 assertions) to confirm the
query change doesn't regress the access-control paths that also touch
this action. `vendor/bin/pint --test` clean.

## Related work / merge order

Independent of #1409 / #1410 (which adds `subtitle` to this same
response, unrelated concern) — no required order between this PR and
that one, they touch the same method but don't depend on each other,
expect a routine rebase whichever lands second.

Once this merges, m3ue/m3u-tv#210's stacked branch and #1410's
sqlite-skipped `search_epg_shows` test case can each simplify slightly
on their next rebase, but that's for those PRs to handle, not blocking
here.