### PR TITLE
feat(epg): expose airing_now on search_epg_shows

### DIFF
--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -240,8 +240,11 @@ class XtreamApiController extends Controller
      * (bool — whether a Series rule already exists for this title), `series_rule_id` (int|null
      * — the existing rule's id when `has_series_rule` is true, for delete-without-round-trip),
      * `channel_count`, `channels` (array of `{channel_id, channel_name}`), `episode_count`,
-     * `next_airing_at` (ISO 8601 or null), `recent_episodes` (up to MAX_RECENT_EPISODES
-     * airings, upcoming first soonest, then most-recent-past).
+     * `next_airing_at` (ISO 8601 or null), `airing_now` (array — programmes currently
+     * in progress on EPG-mapped channels; empty when none, never null; programmes with
+     * an unknown `end_time` are excluded since progress can't be confirmed), and
+     * `recent_episodes` (up to MAX_RECENT_EPISODES airings, upcoming first soonest, then
+     * most-recent-past). Entry shape for `airing_now[]` and `recent_episodes[]` is identical.
      *
      *
      * @param  string  $uuid  The UUID of the playlist (required path parameter)
@@ -3892,21 +3895,27 @@ class XtreamApiController extends Controller
             // is already sorted ascending above, so the first entry is it.
             $nextAiringAt = $upcoming[0]->start_time ?? null;
 
-            $recentEpisodes = array_slice(array_map(function (EpgProgramme $p) use ($channelLookup) {
-                $resolved = $channelLookup[$p->epg_channel_id] ?? null;
+            $recentEpisodes = array_slice(
+                array_map(fn (EpgProgramme $p) => $this->formatEpisodePayload($p, $channelLookup), $progs),
+                0,
+                self::MAX_RECENT_EPISODES,
+            );
 
-                return [
-                    'channel_id' => $resolved['channel_id'] ?? null,
-                    'channel_name' => $resolved['channel_name'] ?? null,
-                    'title' => $p->title,
-                    'subtitle' => $p->subtitle,
-                    'start_time' => $p->start_time->toIso8601String(),
-                    'end_time' => $p->end_time?->toIso8601String(),
-                    'season' => $p->season,
-                    'episode' => $p->episode,
-                    'description' => $p->description,
-                ];
-            }, $progs), 0, self::MAX_RECENT_EPISODES);
+            // airing_now: programmes currently in progress on EPG-mapped channels.
+            // Every in-progress programme has a non-future start, so it lives in $past
+            // (sorted most-recent-start first). Don't assume $past[0] is the answer -
+            // the most recently started programme may have already ended (the test
+            // covers exactly that case). Programmes with a null end_time cannot be
+            // confirmed in progress and are excluded. Always emit an array so the
+            // client doesn't need a null/empty branch.
+            $airingNowProgs = array_values(array_filter(
+                $past,
+                fn (EpgProgramme $p) => $p->end_time !== null && $p->end_time->gt($now),
+            ));
+            $airingNow = array_map(
+                fn (EpgProgramme $p) => $this->formatEpisodePayload($p, $channelLookup),
+                $airingNowProgs,
+            );
 
             $results[] = [
                 'normalized_title' => $norm,
@@ -3917,6 +3926,7 @@ class XtreamApiController extends Controller
                 'channels' => $channels,
                 'episode_count' => count($progs),
                 'next_airing_at' => $nextAiringAt?->toIso8601String(),
+                'airing_now' => $airingNow,
                 'recent_episodes' => $recentEpisodes,
             ];
         }
@@ -3940,6 +3950,32 @@ class XtreamApiController extends Controller
         });
 
         return response()->json(array_slice($results, 0, 100));
+    }
+
+    /**
+     * Build the per-episode payload used by both `recent_episodes[]` and `airing_now[]`
+     * in `search_epg_shows`. The shapes must stay identical so the TV client can parse
+     * either list with its existing `EpgShowEpisode.fromXtream` factory without needing
+     * a second model.
+     *
+     * @param  array<string, array{channel_id: int, channel_name: string}>  $channelLookup
+     * @return array{channel_id: int|null, channel_name: string|null, title: string, subtitle: ?string, start_time: string, end_time: ?string, season: mixed, episode: mixed, description: ?string}
+     */
+    private function formatEpisodePayload(EpgProgramme $p, array $channelLookup): array
+    {
+        $resolved = $channelLookup[$p->epg_channel_id] ?? null;
+
+        return [
+            'channel_id' => $resolved['channel_id'] ?? null,
+            'channel_name' => $resolved['channel_name'] ?? null,
+            'title' => $p->title,
+            'subtitle' => $p->subtitle,
+            'start_time' => $p->start_time->toIso8601String(),
+            'end_time' => $p->end_time?->toIso8601String(),
+            'season' => $p->season,
+            'episode' => $p->episode,
+            'description' => $p->description,
+        ];
     }
 
     /**

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -240,7 +240,7 @@ class XtreamApiController extends Controller
      * (bool — whether a Series rule already exists for this title), `series_rule_id` (int|null
      * — the existing rule's id when `has_series_rule` is true, for delete-without-round-trip),
      * `channel_count`, `channels` (array of `{channel_id, channel_name}`), `episode_count`,
-     * `next_airing_at` (ISO 8601 or null), `airing_now` (array — programmes currently
+     * `next_airing_at` (ISO 8601 or null), `airing_now` (array, programmes currently
      * in progress on EPG-mapped channels; empty when none, never null; programmes with
      * an unknown `end_time` are excluded since progress can't be confirmed), and
      * `recent_episodes` (up to MAX_RECENT_EPISODES airings, upcoming first soonest, then
@@ -3830,10 +3830,17 @@ class XtreamApiController extends Controller
         }
 
         // Fetch matching programmes across all mapped EPG channels, including those
-        // that just finished (up to 24 hours ago) for discoverability.
-        $cutoff = Carbon::now()->subHours(24);
+        // that just finished (up to 24 hours ago) for discoverability. Programmes
+        // still in progress right now are also included even if they started more
+        // than 24 hours ago (e.g. a long-running block or marathon entry), so
+        // airing_now below doesn't silently drop them.
+        $now = Carbon::now();
+        $cutoff = $now->copy()->subHours(24);
         $programmes = EpgProgramme::whereIn('epg_channel_id', $epgChannelIds->toArray())
-            ->where('start_time', '>=', $cutoff)
+            ->where(function ($query) use ($cutoff, $now) {
+                $query->where('start_time', '>=', $cutoff)
+                    ->orWhere('end_time', '>', $now);
+            })
             ->whereRaw('LOWER(title) LIKE LOWER(?)', ['%'.$q.'%'])
             ->limit(500)
             ->get();
@@ -3875,7 +3882,6 @@ class XtreamApiController extends Controller
             // the next actionable airing behind farther-out ones (the bug being
             // fixed in #1411). Don't collapse this back to a single usort without
             // re-checking that case.
-            $now = Carbon::now();
             $upcoming = [];
             $past = [];
             foreach ($progs as $p) {
@@ -3908,10 +3914,23 @@ class XtreamApiController extends Controller
             // covers exactly that case). Programmes with a null end_time cannot be
             // confirmed in progress and are excluded. Always emit an array so the
             // client doesn't need a null/empty branch.
-            $airingNowProgs = array_values(array_filter(
-                $past,
-                fn (EpgProgramme $p) => $p->end_time !== null && $p->end_time->gt($now),
-            ));
+            //
+            // Dedupe by resolved channel_id: overlapping/corrected EPG data can list
+            // more than one in-progress programme for the same channel at once, and
+            // $past's most-recent-start-first order means the first match per channel
+            // is the one to keep.
+            $airingNowByChannel = [];
+            foreach ($past as $p) {
+                if ($p->end_time === null || ! $p->end_time->gt($now)) {
+                    continue;
+                }
+
+                $channelKey = $channelLookup[$p->epg_channel_id]['channel_id'] ?? $p->epg_channel_id;
+                if (! isset($airingNowByChannel[$channelKey])) {
+                    $airingNowByChannel[$channelKey] = $p;
+                }
+            }
+            $airingNowProgs = array_values($airingNowByChannel);
             $airingNow = array_map(
                 fn (EpgProgramme $p) => $this->formatEpisodePayload($p, $channelLookup),
                 $airingNowProgs,

--- a/tests/Feature/SearchEpgShowsOrderingTest.php
+++ b/tests/Feature/SearchEpgShowsOrderingTest.php
@@ -2,9 +2,11 @@
 
 /**
  * Regression coverage for #1411 - `search_epg_shows` `recent_episodes` ordering
- * and cap. The TV client's show-detail screen puts a per-episode "Record" button
- * directly on each `recent_episodes` row (m3u-tv#204), so the list is the picker
- * for which upcoming airing to schedule a recording on.
+ * and cap, plus the `airing_now` field added in the follow-up round. The TV
+ * client's show-detail screen puts a per-episode "Record" button directly on each
+ * `recent_episodes` row (m3u-tv#204), and the "On Now" section (m3u-tv#212) reads
+ * `airing_now`. Both lists are derived from the same programme group, so this
+ * file covers both.
  *
  * Locks in:
  *   1. Upcoming airings appear first, soonest-first - the next actionable airing
@@ -16,6 +18,15 @@
  *      descending-by-timestamp usort would have produced).
  *   4. A show with only past episodes still returns them most-recent-past first
  *      (existing behavior, shouldn't regress).
+ *   5. `airing_now` holds exactly the programmes currently in progress
+ *      (start_time <= now && end_time > now), excluding null end_time. Entry
+ *      shape matches `recent_episodes[]` so the TV client can parse with the
+ *      same factory. Always an array, never null.
+ *   6. The naive `$past[0]` implementation is wrong: the most-recently-started
+ *      programme may have already ended while an earlier, longer one is still
+ *      running. `airing_now` must filter $past, not take its head.
+ *   7. `next_airing_at` and `recent_episodes` ordering stay correct after the
+ *      `airing_now` addition (regression guard on the merged #1411 behaviour).
  */
 
 use App\Models\Channel;
@@ -79,14 +90,38 @@ beforeEach(function () {
     $proxy = Mockery::mock(M3uProxyService::class);
     app()->instance(M3uProxyService::class, $proxy);
 
-    $this->makeProgramme = function (string $title, Carbon $startTime): EpgProgramme {
+    $this->makeProgramme = function (string $title, Carbon $startTime, ?Carbon $endTime = null): EpgProgramme {
         return EpgProgramme::factory()->create([
             'epg_id' => $this->epg->id,
             'epg_channel_id' => $this->epgChannel->channel_id,
             'title' => $title,
             'start_time' => $startTime,
-            'end_time' => $startTime->copy()->addHour(),
+            'end_time' => $endTime ?? $startTime->copy()->addHour(),
         ]);
+    };
+
+    // Build a second Channel <-> EpgChannel pair so tests can exercise a show
+    // airing simultaneously on multiple channels (regional variants, +1
+    // timeshifts) — exactly the case `airing_now` is built to expose.
+    $this->makeChannelPair = function (string $channelId, string $name) {
+        $epgChannel = EpgChannel::factory()->create([
+            'epg_id' => $this->epg->id,
+            'user_id' => $this->user->id,
+            'channel_id' => $channelId,
+            'name' => $name,
+            'display_name' => $name,
+            'lang' => 'en',
+        ]);
+        // The controller resolves channel_name via `$ch->title ?: ($ch->name ?? '')`,
+        // so set `title` (not `title_custom`) to make the value deterministic and
+        // assertable. Factory defaults leave `title` null.
+        $channel = Channel::factory()
+            ->for($this->playlist)
+            ->for($this->group)
+            ->create(['enabled' => true, 'title' => $name]);
+        $channel->update(['epg_channel_id' => $epgChannel->id]);
+
+        return ['epg_channel_id' => $channelId, 'channel_id' => $channel->id, 'name' => $name];
     };
 });
 
@@ -184,4 +219,185 @@ it('falls back to most-recent-past when a show has no upcoming episodes', functi
     // Both past, most-recent-past first.
     expect($episodes[0]['start_time'])->toBe($mostRecent->toIso8601String());
     expect($episodes[1]['start_time'])->toBe($older->toIso8601String());
+});
+
+it('returns airing programmes in airing_now with the same entry shape as recent_episodes', function () {
+    $title = 'Tonight Live';
+    $now = now();
+
+    // Started 10 minutes ago, runs for an hour from now.
+    ($this->makeProgramme)($title, $now->copy()->subMinutes(10), $now->copy()->addMinutes(50));
+
+    $response = $this->postJson(searchShowsUrl('credential-a', 'password-a', 'tonight'))
+        ->assertOk();
+
+    $airingNow = $response->json('0.airing_now');
+    expect($airingNow)->toHaveCount(1);
+
+    // Entry shape must match recent_episodes entries - load one of each and
+    // assert the key sets are equal. `subtitle` is the shared-shape guard
+    // (added by #1409); without it the TV client can't parse `airing_now[]`
+    // with its existing `EpgShowEpisode.fromXtream` factory.
+    $recentKeys = array_keys($response->json('0.recent_episodes.0'));
+    $airingKeys = array_keys($airingNow[0]);
+    expect($airingKeys)->toEqual($recentKeys);
+    expect($airingKeys)->toContain('subtitle');
+});
+
+it('emits an empty airing_now array when nothing is in progress, never null or absent', function () {
+    $title = 'Future Show';
+
+    ($this->makeProgramme)($title, now()->addDays(2)); // future only
+
+    $response = $this->postJson(searchShowsUrl('credential-a', 'password-a', 'future'))
+        ->assertOk();
+
+    $airingNow = $response->json('0.airing_now');
+    expect($airingNow)->toBe([]);
+    expect($airingNow)->not->toBeNull();
+
+    // Key must be present on the result object even when empty.
+    expect($response->json('0'))->toHaveKey('airing_now');
+});
+
+it('lists every channel airing the same show in airing_now with distinct channel_id/name', function () {
+    $title = 'Multi Feed';
+
+    $east = ($this->makeChannelPair)('east.example.com', 'East Feed');
+    $west = ($this->makeChannelPair)('west.example.com', 'West Feed');
+
+    $now = now();
+    EpgProgramme::factory()->create([
+        'epg_id' => $this->epg->id,
+        'epg_channel_id' => $east['epg_channel_id'],
+        'title' => $title,
+        'start_time' => $now->copy()->subMinutes(5),
+        'end_time' => $now->copy()->addHour(),
+    ]);
+    EpgProgramme::factory()->create([
+        'epg_id' => $this->epg->id,
+        'epg_channel_id' => $west['epg_channel_id'],
+        'title' => $title,
+        'start_time' => $now->copy()->subMinutes(5),
+        'end_time' => $now->copy()->addHour(),
+    ]);
+
+    $response = $this->postJson(searchShowsUrl('credential-a', 'password-a', 'multi'))
+        ->assertOk();
+
+    $airingNow = $response->json('0.airing_now');
+    expect($airingNow)->toHaveCount(2);
+
+    $channelIds = collect($airingNow)->pluck('channel_id')->all();
+    expect($channelIds)->toContain($east['channel_id']);
+    expect($channelIds)->toContain($west['channel_id']);
+
+    // Each entry must carry its own channel_name too (used by the TV client
+    // to label the row).
+    $channelNames = collect($airingNow)->pluck('channel_name')->all();
+    expect($channelNames)->toContain('East Feed');
+    expect($channelNames)->toContain('West Feed');
+});
+
+it('excludes past programmes with null end_time from airing_now', function () {
+    $title = 'Noend Show';
+
+    $now = now();
+    // In-progress-looking (start in past) but end_time is unknown - the
+    // controller can't confirm progress, so it must exclude this.
+    EpgProgramme::factory()->create([
+        'epg_id' => $this->epg->id,
+        'epg_channel_id' => $this->epgChannel->channel_id,
+        'title' => $title,
+        'start_time' => $now->copy()->subMinutes(10),
+        'end_time' => null,
+    ]);
+
+    $response = $this->postJson(searchShowsUrl('credential-a', 'password-a', 'noend'))
+        ->assertOk();
+
+    expect($response->json('0.airing_now'))->toBe([]);
+});
+
+it('excludes already-ended programmes even when most-recently-started, not just the naive $past[0] failure mode', function () {
+    $title = 'Tricky Show';
+
+    $now = now();
+
+    // Programme 1: started earliest (-90m), still running (ends in +30m).
+    // Programme 2: started most recently (-5m) but already ended (-1m ago).
+    // A naive `$past[0]` implementation would return programme 2 (most-recent
+    // start, which is at the head of $past). The correct filter rejects
+    // programme 2 because its end_time is in the past, and returns only
+    // programme 1.
+    ($this->makeProgramme)($title, $now->copy()->subMinutes(90), $now->copy()->addMinutes(30));
+    ($this->makeProgramme)($title, $now->copy()->subMinutes(5), $now->copy()->subMinutes(1));
+
+    $response = $this->postJson(searchShowsUrl('credential-a', 'password-a', 'tricky'))
+        ->assertOk();
+
+    $airingNow = $response->json('0.airing_now');
+    expect($airingNow)->toHaveCount(1);
+
+    // The single in-progress programme is the long one (-90m start), not the
+    // most-recent-start (-5m) one which has ended.
+    expect($airingNow[0]['start_time'])->toBe($now->copy()->subMinutes(90)->toIso8601String());
+});
+
+it('treats end_time strictly: end_time equal to now is NOT airing; start_time equal to now IS airing', function () {
+    // Freeze the test clock so the controller's `Carbon::now()` returns the
+    // same timestamp the test uses, making strict `>` boundary assertions
+    // deterministic without flakiness from test-vs-controller clock skew.
+    Carbon::setTestNow('2026-08-13 12:00:00');
+
+    $title = 'Boundary Show';
+    $now = now();
+
+    // Programme A: end_time exactly = now. Condition is `end_time > now`, so
+    // this is NOT airing (already ended at the moment of "now").
+    // Start one hour before to ensure it lands in $past.
+    ($this->makeProgramme)($title, $now->copy()->subHour(), $now->copy());
+
+    // Programme B: start_time exactly = now. That's not in the future, so it
+    // goes to $past, and with an end_time > now it's in progress.
+    ($this->makeProgramme)($title, $now, $now->copy()->addHour());
+
+    $response = $this->postJson(searchShowsUrl('credential-a', 'password-a', 'boundary'))
+        ->assertOk();
+
+    $airingNow = $response->json('0.airing_now');
+    expect($airingNow)->toHaveCount(1);
+    expect($airingNow[0]['start_time'])->toBe($now->toIso8601String());
+    expect($airingNow[0]['end_time'])->toBe($now->copy()->addHour()->toIso8601String());
+
+    Carbon::setTestNow(); // unfreeze for any subsequent tests
+});
+
+it('leaves next_airing_at and recent_episodes ordering untouched by the airing_now addition', function () {
+    $title = 'Steady Show';
+
+    $upcomingSoon = now()->addHours(3);
+    $upcomingLater = now()->addDays(2);
+    $pastRecent = now()->subHours(2);
+
+    // Insert in shuffled order to prove the sorts are doing the work.
+    ($this->makeProgramme)($title, $upcomingLater);
+    ($this->makeProgramme)($title, $pastRecent);
+    ($this->makeProgramme)($title, $upcomingSoon);
+
+    $response = $this->postJson(searchShowsUrl('credential-a', 'password-a', 'steady'))
+        ->assertOk();
+
+    // next_airing_at = soonest upcoming.
+    expect($response->json('0.next_airing_at'))->toBe($upcomingSoon->toIso8601String());
+
+    // recent_episodes ordering unchanged: upcoming-soon, upcoming-later, past.
+    $episodes = $response->json('0.recent_episodes');
+    expect($episodes)->toHaveCount(3);
+    expect($episodes[0]['start_time'])->toBe($upcomingSoon->toIso8601String());
+    expect($episodes[1]['start_time'])->toBe($upcomingLater->toIso8601String());
+    expect($episodes[2]['start_time'])->toBe($pastRecent->toIso8601String());
+
+    // None are airing - all past/outside the live window.
+    expect($response->json('0.airing_now'))->toBe([]);
 });

--- a/tests/Feature/SearchEpgShowsOrderingTest.php
+++ b/tests/Feature/SearchEpgShowsOrderingTest.php
@@ -102,7 +102,7 @@ beforeEach(function () {
 
     // Build a second Channel <-> EpgChannel pair so tests can exercise a show
     // airing simultaneously on multiple channels (regional variants, +1
-    // timeshifts) — exactly the case `airing_now` is built to expose.
+    // timeshifts), exactly the case `airing_now` is built to expose.
     $this->makeChannelPair = function (string $channelId, string $name) {
         $epgChannel = EpgChannel::factory()->create([
             'epg_id' => $this->epg->id,
@@ -400,4 +400,39 @@ it('leaves next_airing_at and recent_episodes ordering untouched by the airing_n
 
     // None are airing - all past/outside the live window.
     expect($response->json('0.airing_now'))->toBe([]);
+});
+
+it('includes a still-running programme in airing_now even when it started more than 24 hours ago', function () {
+    $title = 'Marathon Show';
+    $now = now();
+
+    // Started 30 hours ago (outside the 24h lookback window) but still running
+    // for another hour. The lookback cutoff on start_time must not exclude a
+    // programme that is genuinely in progress right now.
+    ($this->makeProgramme)($title, $now->copy()->subHours(30), $now->copy()->addHour());
+
+    $response = $this->postJson(searchShowsUrl('credential-a', 'password-a', 'marathon'))
+        ->assertOk();
+
+    $airingNow = $response->json('0.airing_now');
+    expect($airingNow)->toHaveCount(1);
+    expect($airingNow[0]['start_time'])->toBe($now->copy()->subHours(30)->toIso8601String());
+});
+
+it('deduplicates airing_now by channel when overlapping EPG data lists two in-progress programmes for the same channel', function () {
+    $title = 'Overlap Show';
+    $now = now();
+
+    // Two overlapping in-progress entries for the same EPG channel (a schedule
+    // correction overlap). Only one row per channel should surface in
+    // airing_now, keeping the most-recently-started of the two.
+    ($this->makeProgramme)($title, $now->copy()->subMinutes(30), $now->copy()->addMinutes(30));
+    ($this->makeProgramme)($title, $now->copy()->subMinutes(5), $now->copy()->addMinutes(55));
+
+    $response = $this->postJson(searchShowsUrl('credential-a', 'password-a', 'overlap'))
+        ->assertOk();
+
+    $airingNow = $response->json('0.airing_now');
+    expect($airingNow)->toHaveCount(1);
+    expect($airingNow[0]['start_time'])->toBe($now->copy()->subMinutes(5)->toIso8601String());
 });


### PR DESCRIPTION
## Problem

`search_epg_shows` has no way to say what a show is airing **right now**.

`next_airing_at` is explicitly the earliest *future* start, so it never covers an in-progress programme. #1412's upcoming-first ordering did make a currently-airing programme *reachable* — it sorts to the head of the past tail — but that's positional rather than guaranteed, and it pushes the work onto every client, which has to re-derive "is this on now?" by comparing timestamps across up to `MAX_RECENT_EPISODES` entries.

## What this adds

An `airing_now` list on each result, alongside `recent_episodes`.

A programme is included when it has **started and not yet ended**. Programmes with an unknown `end_time` are **excluded** — progress can't be confirmed without one, and inferring a duration would be a guess.

**It's a list, not a single entry.** A show can air simultaneously on several channels — regional variants, `+1` timeshifts — and `channel_count > 1` already reflects exactly those. A client offering "tune to this now" needs the choice, so collapsing to one arbitrary entry would throw information away.

**It's always an array, never `null`**, matching how `recent_episodes` already behaves, so clients need no null/empty branch.

## Shared entry shape

The per-episode payload moves into a private `formatEpisodePayload()` used by **both** `airing_now[]` and `recent_episodes[]`, rather than duplicating the literal. If the two shapes drift, a client silently loses fields on one path — this keeps them identical by construction, so a single model parses either list.

## Implementation note

The filter reindexes with `array_values()`. `array_filter` preserves keys, so a filtered-but-not-reindexed array with non-zero keys would `json_encode` as an **object** (`{"1": …}`) rather than an array — which would break list parsing on the client for exactly the non-obvious cases.

The filter runs over the existing `$past` partition (everything in it has a non-future start by construction) and reuses the `$now` already computed for the ordering split, rather than reading the clock a second time within one iteration.

## Testing

`tests/Feature/SearchEpgShowsOrderingTest.php` extended in place — **11 passed, 48 assertions** (4 pre-existing ordering regressions plus 7 new):

- in-progress programme appears with the same entry shape as `recent_episodes`
- nothing in progress → `[]`, not `null` and not absent
- same show on two channels → both entries, each with its own `channel_id`/`channel_name`
- past programme with null `end_time` → excluded
- **already-ended programme excluded even when most-recently-started** — the failure mode a naive `$past[0]` implementation hits, where an earlier longer programme is still running
- strict boundaries: `end_time == now` is **not** airing; `start_time == now` **is**
- `next_airing_at` and `recent_episodes` ordering unchanged

Adjacency check: `XtreamDvrOwnershipTest` — **56 passed, 142 assertions**, confirming the `array_map` → helper refactor didn't disturb the access-gating path. `vendor/bin/pint --test` clean.

## Client

Drives the "On Now" section in m3ue/m3u-tv#212, which is blocked on this. The identical entry shape means the TV client parses `airing_now[]` with its existing `EpgShowEpisode.fromXtream` factory — no new model.