### PR TITLE
feat(dvr): expose comskip EDL on VOD and series library items

### DIFF
--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -1174,6 +1174,28 @@ class XtreamApiController extends Controller
                 }
             }
 
+            // Gate on an episode actually carrying a dvr_recording_id rather
+            // than on $isDvrSeries: DvrVodIntegrationService::findOrCreateSeries
+            // matches by tmdb/tvmaze id or name without filtering on
+            // import_batch_no, so a recording of a show already in the library
+            // attaches its episode to that existing non-DVR series. The check
+            // runs over the already-loaded seasons.episodes, so ordinary series
+            // still cost no extra query.
+            $hasDvrEpisodes = $seriesItem->seasons->contains(
+                fn ($season) => $season->episodes->contains(
+                    fn ($episode) => $episode->dvr_recording_id !== null
+                )
+            );
+
+            $dvrGranted = $hasDvrEpisodes
+                && $this->dvrCapabilityGranted($this->resolveDvrPlaylist($playlist), $authMethod, $playlistAuth);
+
+            if ($dvrGranted) {
+                $seriesItem->load([
+                    'seasons.episodes.dvrRecording' => fn ($query) => $query->with(['dvrSetting', 'recordingRule']),
+                ]);
+            }
+
             $cover = $seriesItem->cover ? (filter_var($seriesItem->cover, FILTER_VALIDATE_URL) ? $seriesItem->cover : $baseUrl."/$seriesItem->cover") : LogoCacheService::getPlaceholderUrl('poster');
             $backdropPaths = $seriesItem->backdrop_path ?? [];
             if (is_string($backdropPaths)) {
@@ -1250,6 +1272,10 @@ class XtreamApiController extends Controller
                                     : $episode->info['cover_big'];
                             }
 
+                            $episodeEdlUrl = $dvrGranted && $episode->dvrRecording
+                                ? $this->dvrEdlUrl($episode->dvrRecording, $username, $password)
+                                : null;
+
                             $seasonEpisodes[] = [
                                 'id' => (string) $episode->id,
                                 'episode_num' => $episode->episode_num,
@@ -1265,6 +1291,11 @@ class XtreamApiController extends Controller
                                 'custom_sid' => $episode->custom_sid ?? '',
                                 'stream_id' => $episode->id,
                                 'direct_source' => '',
+                                // Omitted for ordinary episodes — see get_vod_info.
+                                ...($episodeEdlUrl !== null ? [
+                                    'dvr_uuid' => $episode->dvrRecording->uuid,
+                                    'edl_url' => $episodeEdlUrl,
+                                ] : []),
                             ];
                         }
                     }
@@ -1685,10 +1716,31 @@ class XtreamApiController extends Controller
                 'duration_secs' => $info['duration_secs'] ?? 0,
                 'duration' => $info['duration'] ?? '00:00:00',
                 'bitrate' => $info['bitrate'] ?? 0,
-                'rating' => $channel->rating ?? $info['rating'],
+                // Both sides can legitimately be absent — DVR-integrated movies
+                // carry neither a channel rating nor a 'rating' key in info,
+                // which made this a 500 for exactly those items.
+                'rating' => $channel->rating ?? $info['rating'] ?? '',
                 'releasedate' => $info['releasedate'] ?? $channel->year,
                 'subtitles' => $info['subtitles'] ?? [],
             ];
+
+            // When this library item was integrated from a DVR recording, hand
+            // back the recording's commercial-skip EDL so playback from Movies
+            // gets the same comskip support as playback from the Recordings
+            // screen — same file, so the EDL offsets apply unchanged. Keys are
+            // omitted entirely for ordinary VOD, keeping those payloads
+            // byte-identical to before.
+            if ($channel->dvr_recording_id && $this->dvrCapabilityGranted($this->resolveDvrPlaylist($playlist), $authMethod, $playlistAuth)) {
+                $dvrRecording = $channel->dvrRecording()->with(['dvrSetting', 'recordingRule'])->first();
+                $dvrEdlUrl = $dvrRecording
+                    ? $this->dvrEdlUrl($dvrRecording, $username, $password)
+                    : null;
+
+                if ($dvrEdlUrl !== null) {
+                    $defaultInfo['dvr_uuid'] = $dvrRecording->uuid;
+                    $defaultInfo['edl_url'] = $dvrEdlUrl;
+                }
+            }
 
             // Build movie_data section - use channel's movie_data field if available, otherwise build from channel data
             $movieData = $channel->movie_data ?? [];
@@ -4311,6 +4363,29 @@ class XtreamApiController extends Controller
     }
 
     /**
+     * Build the commercial-skip (EDL) URL for a completed recording, or null
+     * when comskip did not run for it.
+     *
+     * Shared by the DVR actions and by the VOD/series payloads that surface
+     * the same recording once it has been integrated into the library, so both
+     * sides advertise the EDL under identical conditions. Gated on
+     * shouldRunComskip() rather than the DvrSetting flag alone because a
+     * per-rule enable_comskip overrides the setting — checking only the
+     * setting advertises an EDL that was never produced (rule off, setting on)
+     * and hides one that was (rule on, setting off).
+     */
+    private function dvrEdlUrl(DvrRecording $recording, string $username, string $password): ?string
+    {
+        if ($recording->status !== DvrRecordingStatus::Completed || ! $recording->shouldRunComskip()) {
+            return null;
+        }
+
+        $baseUrl = config('app.url');
+
+        return "{$baseUrl}/dvr/{$username}/{$password}/{$recording->uuid}/edl";
+    }
+
+    /**
      * Format a DvrRecording into the API response shape.
      */
     private function formatDvrRecording(DvrRecording $recording, string $username, string $password, bool $full = false): array
@@ -4332,10 +4407,8 @@ class XtreamApiController extends Controller
             ? "{$baseUrl}/dvr/{$username}/{$password}/{$recording->uuid}/live.m3u8"
             : null;
 
-        $hasEdl = $isCompleted && ($recording->dvrSetting?->enable_comskip ?? false);
-        $edlUrl = $hasEdl
-            ? "{$baseUrl}/dvr/{$username}/{$password}/{$recording->uuid}/edl"
-            : null;
+        $edlUrl = $this->dvrEdlUrl($recording, $username, $password);
+        $hasEdl = $edlUrl !== null;
 
         $data = [
             'uuid' => $recording->uuid,

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -1188,7 +1188,7 @@ class XtreamApiController extends Controller
             );
 
             $dvrGranted = $hasDvrEpisodes
-                && $this->dvrCapabilityGranted($this->resolveDvrPlaylist($playlist), $authMethod, $playlistAuth);
+                && $this->canAdvertiseDvrFeature($playlist, $authMethod, $playlistAuth);
 
             if ($dvrGranted) {
                 $seriesItem->load([
@@ -1272,7 +1272,9 @@ class XtreamApiController extends Controller
                                     : $episode->info['cover_big'];
                             }
 
-                            $episodeEdlUrl = $dvrGranted && $episode->dvrRecording
+                            $episodeEdlUrl = $dvrGranted
+                                && $episode->dvrRecording
+                                && $this->dvrRecordingVisibleToCaller($episode->dvrRecording, $authMethod, $playlistAuth)
                                 ? $this->dvrEdlUrl($episode->dvrRecording, $username, $password)
                                 : null;
 
@@ -1730,9 +1732,9 @@ class XtreamApiController extends Controller
             // screen — same file, so the EDL offsets apply unchanged. Keys are
             // omitted entirely for ordinary VOD, keeping those payloads
             // byte-identical to before.
-            if ($channel->dvr_recording_id && $this->dvrCapabilityGranted($this->resolveDvrPlaylist($playlist), $authMethod, $playlistAuth)) {
+            if ($channel->dvr_recording_id && $this->canAdvertiseDvrFeature($playlist, $authMethod, $playlistAuth)) {
                 $dvrRecording = $channel->dvrRecording()->with(['dvrSetting', 'recordingRule'])->first();
-                $dvrEdlUrl = $dvrRecording
+                $dvrEdlUrl = $dvrRecording && $this->dvrRecordingVisibleToCaller($dvrRecording, $authMethod, $playlistAuth)
                     ? $this->dvrEdlUrl($dvrRecording, $username, $password)
                     : null;
 
@@ -3544,6 +3546,23 @@ class XtreamApiController extends Controller
     }
 
     /**
+     * Whether a specific recording's EDL/DVR metadata may be surfaced to the
+     * caller. DVR recording listings (getDvrRecordings/getDvrRecording) scope
+     * their query by playlist_auth_id, but the VOD/series library items a
+     * recording gets integrated into are playlist-wide, not per-guest - so
+     * advertising edl_url there needs its own ownership check, mirroring the
+     * scoping DvrStreamController::edl() enforces when actually serving it.
+     */
+    private function dvrRecordingVisibleToCaller(DvrRecording $recording, string $authMethod, ?PlaylistAuth $playlistAuth): bool
+    {
+        if ($authMethod === 'playlist_auth') {
+            return $recording->playlist_auth_id === $playlistAuth?->id;
+        }
+
+        return true;
+    }
+
+    /**
      * Single source of truth for whether DVR is usable at all: global config,
      * the effective playlist's DvrSetting, and (for guest credentials) the
      * PlaylistAuth's own dvr_enabled flag. Both feature advertisement and every
@@ -3664,7 +3683,7 @@ class XtreamApiController extends Controller
 
         $query = DvrRecording::where('dvr_setting_id', $dvrSetting->id)
             ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
-            ->with('channel')
+            ->with(['channel', 'dvrSetting', 'recordingRule'])
             ->orderByDesc('scheduled_start');
 
         if ($status) {
@@ -3699,7 +3718,7 @@ class XtreamApiController extends Controller
         $recording = DvrRecording::where('dvr_setting_id', $dvrSetting->id)
             ->where('uuid', $uuid)
             ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
-            ->with('channel')
+            ->with(['channel', 'dvrSetting', 'recordingRule'])
             ->first();
 
         if (! $recording) {

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -181,6 +181,12 @@ class Channel extends Model
             ->withoutEagerLoads();
     }
 
+    /** The DVR recording this VOD channel was integrated from, if any. */
+    public function dvrRecording(): BelongsTo
+    {
+        return $this->belongsTo(DvrRecording::class);
+    }
+
     public function aedProfile(): BelongsTo
     {
         return $this->belongsTo(AedProfile::class);

--- a/app/Models/Episode.php
+++ b/app/Models/Episode.php
@@ -122,6 +122,12 @@ class Episode extends Model
         return $this->belongsTo(Series::class, 'series_id');
     }
 
+    /** The DVR recording this episode was integrated from, if any. */
+    public function dvrRecording(): BelongsTo
+    {
+        return $this->belongsTo(DvrRecording::class);
+    }
+
     /**
      * Get all STRM file mappings for this episode
      */

--- a/tests/Feature/XtreamDvrEdlOnLibraryItemsTest.php
+++ b/tests/Feature/XtreamDvrEdlOnLibraryItemsTest.php
@@ -1,0 +1,258 @@
+<?php
+
+/**
+ * Coverage for commercial-skip (comskip/EDL) on DVR recordings once they have
+ * been integrated into the VOD/Series library.
+ *
+ * Before this, `edl_url` was emitted only by `get_dvr_recordings`, so playing a
+ * recording from the Recordings screen got comskip while playing the exact same
+ * file from Movies or Series silently did not — the client had no way to reach
+ * the EDL. `DvrVodIntegrationService` writes real Channel / Series+Season+Episode
+ * rows carrying `dvr_recording_id`, but none of the VOD/series payloads
+ * serialized it.
+ *
+ * Locks in:
+ *   1. `get_vod_info` emits `edl_url`/`dvr_uuid` for a DVR-backed movie.
+ *   2. `get_series_info` emits them per-episode for a DVR-backed episode.
+ *   3. Ordinary VOD/series payloads are unchanged — no keys at all.
+ *   4. The keys are withheld when comskip did not run for the recording,
+ *      including the per-rule override case (rule off, setting on), which the
+ *      old DvrSetting-only gate got wrong in both directions.
+ *   5. A credential without DVR access is never handed an EDL URL.
+ */
+
+use App\Enums\DvrRecordingStatus;
+use App\Models\Channel;
+use App\Models\DvrRecording;
+use App\Models\DvrRecordingRule;
+use App\Models\DvrSetting;
+use App\Models\Episode;
+use App\Models\Group;
+use App\Models\Playlist;
+use App\Models\PlaylistAuth;
+use App\Models\Season;
+use App\Models\Series;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::factory()->for($this->user)->create();
+    $this->group = Group::factory()->for($this->user)->create();
+
+    $this->playlistAuth = PlaylistAuth::create([
+        'name' => 'EDL Test Auth',
+        'username' => 'edl-user',
+        'password' => 'edl-pass',
+        'enabled' => true,
+        'dvr_enabled' => true,
+        'user_id' => $this->user->id,
+    ]);
+    $this->playlist->playlistAuths()->attach($this->playlistAuth);
+
+    $this->setting = DvrSetting::factory()
+        ->enabled()
+        ->for($this->user)
+        ->for($this->playlist)
+        ->create(['enable_comskip' => true]);
+
+    $this->recording = DvrRecording::factory()
+        ->completed()
+        ->for($this->user)
+        ->for($this->setting)
+        // Guest-scheduled recordings carry the credential that made them; the
+        // EDL route scopes on it for guest credentials.
+        ->create(['playlist_auth_id' => $this->playlistAuth->id]);
+});
+
+function dvrEdlApiUrl(string $action, array $params = [], string $username = 'edl-user', string $password = 'edl-pass'): string
+{
+    return route('xtream.api.player').'?'.http_build_query(array_merge([
+        'username' => $username,
+        'password' => $password,
+        'action' => $action,
+    ], $params));
+}
+
+function dvrEdlVodChannel($test, ?int $dvrRecordingId): Channel
+{
+    $isDvr = $dvrRecordingId !== null;
+
+    return Channel::factory()
+        ->for($test->playlist)
+        ->for($test->group)
+        ->create([
+            'enabled' => true,
+            'is_vod' => true,
+            'name' => 'Recorded Movie',
+            'title' => 'Recorded Movie',
+            // Mirror what DvrVodIntegrationService::integrateAsMovie actually
+            // writes: is_custom with no last_metadata_fetch. Pinning the fetch
+            // timestamp instead would skip the metadata path the real rows take.
+            'is_custom' => $isDvr,
+            'last_metadata_fetch' => $isDvr ? null : now(),
+            'dvr_recording_id' => $dvrRecordingId,
+        ]);
+}
+
+function dvrEdlEpisode($test, ?int $dvrRecordingId, string $importBatchNo = 'dvr'): Episode
+{
+    $series = Series::factory()
+        ->for($test->user)
+        ->for($test->playlist)
+        ->create(['enabled' => true, 'import_batch_no' => $importBatchNo]);
+
+    $season = Season::factory()
+        ->for($test->user)
+        ->for($test->playlist)
+        ->for($series)
+        ->create(['season_number' => 1]);
+
+    return Episode::factory()
+        ->for($test->user)
+        ->for($test->playlist)
+        ->for($series)
+        ->for($season)
+        ->create([
+            'season' => 1,
+            'episode_num' => 1,
+            'title' => 'Recorded Episode',
+            'import_batch_no' => $importBatchNo,
+            'dvr_recording_id' => $dvrRecordingId,
+        ]);
+}
+
+it('emits edl_url and dvr_uuid on get_vod_info for a DVR-backed movie', function () {
+    $channel = dvrEdlVodChannel($this, $this->recording->id);
+
+    $response = $this->getJson(dvrEdlApiUrl('get_vod_info', ['vod_id' => $channel->id]))->assertOk();
+
+    $expected = config('app.url')."/dvr/edl-user/edl-pass/{$this->recording->uuid}/edl";
+
+    expect($response->json('info.edl_url'))->toBe($expected)
+        ->and($response->json('info.dvr_uuid'))->toBe($this->recording->uuid)
+        // Merged to root as well, matching how the rest of this payload is shaped.
+        ->and($response->json('edl_url'))->toBe($expected);
+});
+
+it('emits an edl_url that actually resolves to the EDL endpoint', function () {
+    // The other tests compare against a string built the same way the code
+    // builds it, so they would keep passing if the path shape drifted on both
+    // sides. This one follows the URL the client would actually be handed.
+    $channel = dvrEdlVodChannel($this, $this->recording->id);
+
+    $response = $this->getJson(dvrEdlApiUrl('get_vod_info', ['vod_id' => $channel->id]))->assertOk();
+
+    $disk = $this->recording->resolveStorageDisk();
+    Storage::fake($disk);
+    $edlPath = preg_replace('/\.[^.]+$/', '.edl', $this->recording->file_path);
+    Storage::disk($disk)->put($edlPath, "10.5 40.25 0\n120.0 180.0 1\n");
+
+    $this->getJson($response->json('info.edl_url'))
+        ->assertOk()
+        // type 1 lines are not commercial cuts and must be filtered out
+        ->assertExactJson([['start' => 10.5, 'end' => 40.25]]);
+});
+
+it('omits the edl keys on get_vod_info for an ordinary movie', function () {
+    $channel = dvrEdlVodChannel($this, null);
+
+    $response = $this->getJson(dvrEdlApiUrl('get_vod_info', ['vod_id' => $channel->id]))->assertOk();
+
+    expect($response->json('info'))->not->toHaveKey('edl_url')
+        ->and($response->json('info'))->not->toHaveKey('dvr_uuid');
+});
+
+it('emits edl_url and dvr_uuid per episode on get_series_info', function () {
+    $episode = dvrEdlEpisode($this, $this->recording->id);
+
+    $response = $this->getJson(dvrEdlApiUrl('get_series_info', ['series_id' => $episode->series_id]))->assertOk();
+
+    $payload = $response->json('episodes.1.0');
+
+    expect($payload['edl_url'])->toBe(config('app.url')."/dvr/edl-user/edl-pass/{$this->recording->uuid}/edl")
+        ->and($payload['dvr_uuid'])->toBe($this->recording->uuid);
+});
+
+it('emits edl_url for a DVR episode attached to a non-DVR series', function () {
+    // findOrCreateSeries matches by tmdb/tvmaze id or name without filtering on
+    // import_batch_no, so recording a show that is already in the library hangs
+    // the DVR episode off the existing upstream series. Gating on the series'
+    // import_batch_no would silently lose comskip for exactly these.
+    $episode = dvrEdlEpisode($this, $this->recording->id, importBatchNo: 'upstream');
+
+    $response = $this->getJson(dvrEdlApiUrl('get_series_info', ['series_id' => $episode->series_id]))->assertOk();
+
+    expect($response->json('episodes.1.0.edl_url'))
+        ->toBe(config('app.url')."/dvr/edl-user/edl-pass/{$this->recording->uuid}/edl");
+});
+
+it('omits the edl keys on get_series_info for an ordinary episode', function () {
+    $episode = dvrEdlEpisode($this, null, importBatchNo: 'upstream');
+
+    $response = $this->getJson(dvrEdlApiUrl('get_series_info', ['series_id' => $episode->series_id]))->assertOk();
+
+    expect($response->json('episodes.1.0'))->not->toHaveKey('edl_url')
+        ->and($response->json('episodes.1.0'))->not->toHaveKey('dvr_uuid');
+});
+
+it('withholds the edl url when comskip is disabled for the recording', function () {
+    $this->setting->update(['enable_comskip' => false]);
+    $channel = dvrEdlVodChannel($this, $this->recording->id);
+
+    $response = $this->getJson(dvrEdlApiUrl('get_vod_info', ['vod_id' => $channel->id]))->assertOk();
+
+    expect($response->json('info'))->not->toHaveKey('edl_url');
+});
+
+it('honours a per-rule comskip override that disagrees with the setting', function () {
+    // The old gate read DvrSetting::enable_comskip alone, but
+    // DvrRecording::shouldRunComskip() lets a per-rule flag win. Setting on +
+    // rule off means comskip never ran, so no EDL file exists — advertising one
+    // sends the client after a 404.
+    $rule = DvrRecordingRule::factory()
+        ->for($this->user)
+        ->for($this->setting)
+        ->create(['enable_comskip' => false]);
+
+    $this->recording->update(['dvr_recording_rule_id' => $rule->id]);
+
+    $channel = dvrEdlVodChannel($this, $this->recording->id);
+
+    $response = $this->getJson(dvrEdlApiUrl('get_vod_info', ['vod_id' => $channel->id]))->assertOk();
+
+    expect($response->json('info'))->not->toHaveKey('edl_url');
+
+    // ...and the inverse: setting off + rule on means the .edl does exist.
+    $this->setting->update(['enable_comskip' => false]);
+    $rule->update(['enable_comskip' => true]);
+
+    $response = $this->getJson(dvrEdlApiUrl('get_vod_info', ['vod_id' => $channel->id]))->assertOk();
+
+    expect($response->json('info.edl_url'))
+        ->toBe(config('app.url')."/dvr/edl-user/edl-pass/{$this->recording->uuid}/edl");
+});
+
+it('withholds the edl url from a credential without DVR access', function () {
+    $this->playlistAuth->update(['dvr_enabled' => false]);
+    $channel = dvrEdlVodChannel($this, $this->recording->id);
+
+    $response = $this->getJson(dvrEdlApiUrl('get_vod_info', ['vod_id' => $channel->id]))->assertOk();
+
+    expect($response->json('info'))->not->toHaveKey('edl_url');
+});
+
+it('withholds the edl url for a recording that has not completed', function () {
+    $this->recording->update(['status' => DvrRecordingStatus::Recording]);
+    $channel = dvrEdlVodChannel($this, $this->recording->id);
+
+    $response = $this->getJson(dvrEdlApiUrl('get_vod_info', ['vod_id' => $channel->id]))->assertOk();
+
+    expect($response->json('info'))->not->toHaveKey('edl_url');
+});

--- a/tests/Feature/XtreamDvrEdlOnLibraryItemsTest.php
+++ b/tests/Feature/XtreamDvrEdlOnLibraryItemsTest.php
@@ -256,3 +256,65 @@ it('withholds the edl url for a recording that has not completed', function () {
 
     expect($response->json('info'))->not->toHaveKey('edl_url');
 });
+
+it('withholds the edl url on get_vod_info from a guest credential that does not own the recording', function () {
+    // VOD library items are playlist-wide, not per-guest, so a second guest with
+    // dvr_enabled can see the same movie. DvrStreamController::edl() scopes by
+    // playlist_auth_id for guest credentials, so advertising an edl_url built
+    // with the other guest's own username/password sends them at a URL that
+    // 404s for a recording they don't own.
+    $otherAuth = PlaylistAuth::create([
+        'name' => 'Other EDL Test Auth',
+        'username' => 'edl-user-2',
+        'password' => 'edl-pass-2',
+        'enabled' => true,
+        'dvr_enabled' => true,
+        'user_id' => $this->user->id,
+    ]);
+    $this->playlist->playlistAuths()->attach($otherAuth);
+
+    $channel = dvrEdlVodChannel($this, $this->recording->id);
+
+    $response = $this->getJson(dvrEdlApiUrl('get_vod_info', ['vod_id' => $channel->id], 'edl-user-2', 'edl-pass-2'))->assertOk();
+
+    expect($response->json('info'))->not->toHaveKey('edl_url')
+        ->and($response->json('info'))->not->toHaveKey('dvr_uuid');
+});
+
+it('withholds the edl url on get_series_info from a guest credential that does not own the recording', function () {
+    $otherAuth = PlaylistAuth::create([
+        'name' => 'Other EDL Test Auth',
+        'username' => 'edl-user-2',
+        'password' => 'edl-pass-2',
+        'enabled' => true,
+        'dvr_enabled' => true,
+        'user_id' => $this->user->id,
+    ]);
+    $this->playlist->playlistAuths()->attach($otherAuth);
+
+    $episode = dvrEdlEpisode($this, $this->recording->id);
+
+    $response = $this->getJson(dvrEdlApiUrl('get_series_info', ['series_id' => $episode->series_id], 'edl-user-2', 'edl-pass-2'))->assertOk();
+
+    expect($response->json('episodes.1.0'))->not->toHaveKey('edl_url')
+        ->and($response->json('episodes.1.0'))->not->toHaveKey('dvr_uuid');
+});
+
+it('still emits the edl url on get_vod_info for the owning credential when other guests have dvr access', function () {
+    $otherAuth = PlaylistAuth::create([
+        'name' => 'Other EDL Test Auth',
+        'username' => 'edl-user-2',
+        'password' => 'edl-pass-2',
+        'enabled' => true,
+        'dvr_enabled' => true,
+        'user_id' => $this->user->id,
+    ]);
+    $this->playlist->playlistAuths()->attach($otherAuth);
+
+    $channel = dvrEdlVodChannel($this, $this->recording->id);
+
+    $response = $this->getJson(dvrEdlApiUrl('get_vod_info', ['vod_id' => $channel->id]))->assertOk();
+
+    expect($response->json('info.edl_url'))
+        ->toBe(config('app.url')."/dvr/edl-user/edl-pass/{$this->recording->uuid}/edl");
+});


### PR DESCRIPTION
## Problem

A completed DVR recording is integrated into the library as a real `Channel` (movie) or `Series`/`Season`/`Episode` row, carrying a `dvr_recording_id`. But none of the Xtream payloads serialized anything tying that row back to its recording — `direct_source` is hard-coded `''`, so even `channels.url` (which contains the recording UUID) never reaches the client.

`edl_url` was emitted only by `get_dvr_recordings`. So a client can offer commercial skipping when playing from the Recordings screen, and cannot when playing the **exact same file** from Movies or Series. Not a regression — an unimplemented path.

## What this does

- Adds `Channel::dvrRecording()` / `Episode::dvrRecording()` `belongsTo` for the existing `dvr_recording_id` columns. Only the inverse side (`DvrRecording::vodChannel()` / `vodEpisode()`) existed.
- Extracts the EDL URL construction out of `formatDvrRecording()` into a shared helper, so the DVR and library payloads cannot drift apart.
- Emits `edl_url` and `dvr_uuid` from `get_vod_info` and `get_series_info` for DVR-backed items only. Keys are **omitted entirely** otherwise, so ordinary VOD/series payloads are byte-identical to before. Both sites are gated on DVR capability.

## Two fixes that were required to make this reachable

**`get_vod_info` returned a 500 for every DVR-integrated movie.** `$channel->rating ?? $info['rating']` was unguarded, and `DvrVodIntegrationService` writes neither a channel rating nor a `rating` key in `info`. The endpoint errored on exactly the items this feature targets, so the feature was unreachable until this was fixed.

**The comskip gate disagreed with the code that actually runs comskip.** `formatDvrRecording()` checked `dvrSetting->enable_comskip`, but `DvrRecording::shouldRunComskip()` lets a per-rule `enable_comskip` override the setting. The old check advertised an EDL that was never produced (rule off, setting on) and hid one that was (rule on, setting off). Now gated on `shouldRunComskip()`. This also fixes the existing Recordings path.

## Design note

The series-side gate checks whether an episode actually carries a `dvr_recording_id`, **not** the series' `import_batch_no`. `DvrVodIntegrationService::findOrCreateSeries` matches by tmdb/tvmaze id or name without filtering on `import_batch_no`, so recording a show already in the library hangs its episode off the existing upstream series. Gating on the series would have silently lost comskip for exactly those episodes. The check runs over already-loaded `seasons.episodes`, so ordinary series cost no extra query.

`get_vod_streams` deliberately does **not** emit `edl_url` — it serves a streaming cursor and a per-row lookup would be an N+1 across the whole library. The client resolves that case lazily via `get_vod_info`.

## Tests

10 feature tests in `tests/Feature/XtreamDvrEdlOnLibraryItemsTest.php`, all mutation-checked (reverting the comskip gate, the emission, or the series gate each fails the corresponding test). One test follows the emitted URL end-to-end to the EDL endpoint and parses a real `.edl`, rather than comparing against a string built the same way the code builds it — that test caught a real `playlist_auth_id` scoping detail a string comparison would have missed.

`vendor/bin/pint` clean. Full `Xtream|Dvr` filter shows no regressions against baseline.

## Verification

Verified live against a real DVR-integrated movie and a real DVR-integrated episode on a running instance. Commercial skipping confirmed working end-to-end from Movies and Series with the matching client change.

## Related

Client half: m3ue/m3u-tv `fix/comskip-in-movies-series`. This PR must land first — the client degrades silently against a server without these fields.