### PR TITLE
fix(dvr): improve Browse Shows flag chip legibility on poster artwork

### DIFF
--- a/resources/views/filament/guest-panel/pages/browse-shows.blade.php
+++ b/resources/views/filament/guest-panel/pages/browse-shows.blade.php
@@ -99,21 +99,33 @@
                             @endif
 
                             @if ($show['has_series_rule'])
-                                <div class="absolute top-2 right-2">
-                                    <x-filament::badge color="success">{{ __('Series') }}</x-filament::badge>
+                                <div class="absolute top-2 right-2 inline-flex items-center rounded-md bg-gray-900/70 ring-1 ring-white/10 backdrop-blur-sm">
+                                    <x-filament::badge color="success" icon="heroicon-s-queue-list" size="sm" class="!bg-emerald-600 !text-white">
+                                        {{ __('Series') }}
+                                    </x-filament::badge>
                                 </div>
                             @elseif ($show['has_once_rule'])
-                                <div class="absolute top-2 right-2">
-                                    <x-filament::badge color="info">{{ __('Scheduled') }}</x-filament::badge>
+                                <div class="absolute top-2 right-2 inline-flex items-center rounded-md bg-gray-900/70 ring-1 ring-white/10 backdrop-blur-sm">
+                                    <x-filament::badge color="info" icon="heroicon-s-clock" size="sm">
+                                        {{ __('Scheduled') }}
+                                    </x-filament::badge>
                                 </div>
                             @endif
 
-                            <div class="absolute top-2 left-2 flex flex-col gap-1">
+                            <div class="absolute top-2 left-2 flex flex-col items-start gap-1">
                                 @if ($show['flags']['is_new'])
-                                    <x-filament::badge color="success">{{ __('New') }}</x-filament::badge>
+                                    <div class="inline-flex items-center rounded-md bg-gray-900/70 ring-1 ring-white/10 backdrop-blur-sm">
+                                        <x-filament::badge color="success" icon="heroicon-s-sparkles" size="sm" class="!bg-emerald-600 !text-white">
+                                            {{ __('New') }}
+                                        </x-filament::badge>
+                                    </div>
                                 @endif
                                 @if ($show['flags']['premiere'])
-                                    <x-filament::badge color="warning">{{ __('Premiere') }}</x-filament::badge>
+                                    <div class="inline-flex items-center rounded-md bg-gray-900/70 ring-1 ring-white/10 backdrop-blur-sm">
+                                        <x-filament::badge color="warning" icon="heroicon-s-star" size="sm">
+                                            {{ __('Premiere') }}
+                                        </x-filament::badge>
+                                    </div>
                                 @endif
                             </div>
                         </button>

--- a/resources/views/filament/guest-panel/pages/browse-shows.blade.php
+++ b/resources/views/filament/guest-panel/pages/browse-shows.blade.php
@@ -100,7 +100,12 @@
 
                             @if ($show['has_series_rule'])
                                 <div class="absolute top-2 right-2 inline-flex items-center rounded-md bg-gray-900/70 ring-1 ring-white/10 backdrop-blur-sm">
-                                    <x-filament::badge color="success" icon="heroicon-s-queue-list" size="sm" class="!bg-emerald-600 !text-white">
+                                    <x-filament::badge
+                                        color="success"
+                                        icon="heroicon-s-queue-list"
+                                        size="sm"
+                                        class="!bg-emerald-600 !text-white"
+                                    >
                                         {{ __('Series') }}
                                     </x-filament::badge>
                                 </div>
@@ -115,7 +120,12 @@
                             <div class="absolute top-2 left-2 flex flex-col items-start gap-1">
                                 @if ($show['flags']['is_new'])
                                     <div class="inline-flex items-center rounded-md bg-gray-900/70 ring-1 ring-white/10 backdrop-blur-sm">
-                                        <x-filament::badge color="success" icon="heroicon-s-sparkles" size="sm" class="!bg-emerald-600 !text-white">
+                                        <x-filament::badge
+                                            color="success"
+                                            icon="heroicon-s-sparkles"
+                                            size="sm"
+                                            class="!bg-emerald-600 !text-white"
+                                        >
                                             {{ __('New') }}
                                         </x-filament::badge>
                                     </div>

--- a/resources/views/filament/pages/browse-shows.blade.php
+++ b/resources/views/filament/pages/browse-shows.blade.php
@@ -130,21 +130,33 @@
                             @endif
 
                             @if ($show['has_series_rule'])
-                                <div class="absolute top-2 right-2">
-                                    <x-filament::badge color="success">{{ __('Series') }}</x-filament::badge>
+                                <div class="absolute top-2 right-2 inline-flex items-center rounded-md bg-gray-900/70 ring-1 ring-white/10 backdrop-blur-sm">
+                                    <x-filament::badge color="success" icon="heroicon-s-queue-list" size="sm" class="!bg-emerald-600 !text-white">
+                                        {{ __('Series') }}
+                                    </x-filament::badge>
                                 </div>
                             @elseif ($show['has_once_rule'])
-                                <div class="absolute top-2 right-2">
-                                    <x-filament::badge color="info">{{ __('Scheduled') }}</x-filament::badge>
+                                <div class="absolute top-2 right-2 inline-flex items-center rounded-md bg-gray-900/70 ring-1 ring-white/10 backdrop-blur-sm">
+                                    <x-filament::badge color="info" icon="heroicon-s-clock" size="sm">
+                                        {{ __('Scheduled') }}
+                                    </x-filament::badge>
                                 </div>
                             @endif
 
-                            <div class="absolute top-2 left-2 flex flex-col gap-1">
+                            <div class="absolute top-2 left-2 flex flex-col items-start gap-1">
                                 @if ($show['flags']['is_new'])
-                                    <x-filament::badge color="success">{{ __('New') }}</x-filament::badge>
+                                    <div class="inline-flex items-center rounded-md bg-gray-900/70 ring-1 ring-white/10 backdrop-blur-sm">
+                                        <x-filament::badge color="success" icon="heroicon-s-sparkles" size="sm" class="!bg-emerald-600 !text-white">
+                                            {{ __('New') }}
+                                        </x-filament::badge>
+                                    </div>
                                 @endif
                                 @if ($show['flags']['premiere'])
-                                    <x-filament::badge color="warning">{{ __('Premiere') }}</x-filament::badge>
+                                    <div class="inline-flex items-center rounded-md bg-gray-900/70 ring-1 ring-white/10 backdrop-blur-sm">
+                                        <x-filament::badge color="warning" icon="heroicon-s-star" size="sm">
+                                            {{ __('Premiere') }}
+                                        </x-filament::badge>
+                                    </div>
                                 @endif
                             </div>
                         </button>

--- a/resources/views/filament/pages/browse-shows.blade.php
+++ b/resources/views/filament/pages/browse-shows.blade.php
@@ -131,7 +131,12 @@
 
                             @if ($show['has_series_rule'])
                                 <div class="absolute top-2 right-2 inline-flex items-center rounded-md bg-gray-900/70 ring-1 ring-white/10 backdrop-blur-sm">
-                                    <x-filament::badge color="success" icon="heroicon-s-queue-list" size="sm" class="!bg-emerald-600 !text-white">
+                                    <x-filament::badge
+                                        color="success"
+                                        icon="heroicon-s-queue-list"
+                                        size="sm"
+                                        class="!bg-emerald-600 !text-white"
+                                    >
                                         {{ __('Series') }}
                                     </x-filament::badge>
                                 </div>
@@ -146,7 +151,12 @@
                             <div class="absolute top-2 left-2 flex flex-col items-start gap-1">
                                 @if ($show['flags']['is_new'])
                                     <div class="inline-flex items-center rounded-md bg-gray-900/70 ring-1 ring-white/10 backdrop-blur-sm">
-                                        <x-filament::badge color="success" icon="heroicon-s-sparkles" size="sm" class="!bg-emerald-600 !text-white">
+                                        <x-filament::badge
+                                            color="success"
+                                            icon="heroicon-s-sparkles"
+                                            size="sm"
+                                            class="!bg-emerald-600 !text-white"
+                                        >
                                             {{ __('New') }}
                                         </x-filament::badge>
                                     </div>


### PR DESCRIPTION
## Summary

The four flag chips on the Browse Shows card grid (New / Premiere / Series / Scheduled) used Filament's tinted-badge palette, which falls below ~3:1 contrast against bright poster imagery, making them hard to read at thumbnail size.

## Changes

- Wrap each chip in a dark backdrop pill (`bg-gray-900/70` + `ring-1 ring-white/10` + `backdrop-blur-sm`) so the chip stays readable on top of any poster artwork.
- Add solid `heroicon-s-*` icons (`sparkles` / `star` / `queue-list` / `clock`) so each chip remains scannable without relying on color alone.
- Shrink to `size="sm"` so the badge doesn't crowd the poster corner.
- Force the success-tinted chips (`New` and `Series`) to solid `emerald-600` + white text via `!important` Tailwind overrides, since Filament's default success palette still leaves green-on-green inside the badge.
- Mirror the change in both admin and guest-panel variants for parity (same template changes in `resources/views/filament/pages/browse-shows.blade.php` and `resources/views/filament/guest-panel/pages/browse-shows.blade.php`).

## Test plan

- [x] `npm run build` and visual check on a Browse Shows page with bright poster art (where the original complaint arose), in both light and dark mode.
- [x] Confirm the four chips read clearly: solid green for New/Series, crisp blue for Scheduled, amber for Premiere — all against backdrop pills.
- [x] Confirm the slide-over detail (top-right action menu, dropdown items) still works.
- [x] Existing Pest tests pass (no state changes): `vendor/bin/pest --filter=BrowseShows`.