### PR TITLE
fix: resolve local SchedulesDirect EPG fallback

### DIFF
--- a/app/Http/Controllers/EpgGenerateController.php
+++ b/app/Http/Controllers/EpgGenerateController.php
@@ -896,6 +896,7 @@ class EpgGenerateController extends Controller
     {
         // Get the content
         $filePath = null;
+        $error = null;
         if ($epg->url && str_starts_with($epg->url, 'http')) {
             $localPath = Storage::disk('local')->path($epg->file_path);
             if (! file_exists($localPath)) {
@@ -908,11 +909,19 @@ class EpgGenerateController extends Controller
             $filePath = Storage::disk('local')->path($epg->uploads);
         } elseif ($epg->url) {
             $filePath = $epg->url;
+        } elseif ($epg->isSchedulesDirect()) {
+            $localPath = Storage::disk('local')->path($epg->file_path);
+            if (file_exists($localPath)) {
+                $filePath = $localPath;
+            } else {
+                Log::warning("SchedulesDirect EPG source file not found on disk for EPG \"{$epg->name}\": {$localPath}");
+                $error = 'SchedulesDirect EPG source file is missing from local storage. Please sync the EPG and try again.';
+            }
         }
 
         if (! $filePath) {
             // Send notification
-            $error = 'Invalid EPG file. Unable to read or download an associated EPG file. Please check the URL or uploaded file and try again.';
+            $error ??= 'Invalid EPG file. Unable to read or download an associated EPG file. Please check the URL or uploaded file and try again.';
             Notification::make()
                 ->danger()
                 ->title("Error generating epg data for playlist \"{$playlist->name}\" using EPG \"{$epg->name}\"")

--- a/tests/Feature/EpgGenerateControllerTest.php
+++ b/tests/Feature/EpgGenerateControllerTest.php
@@ -16,8 +16,10 @@ use App\Models\EpgChannel;
 use App\Models\Playlist;
 use App\Models\User;
 use App\Services\EpgCacheService;
+use Filament\Notifications\DatabaseNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
 use Illuminate\Support\Facades\Storage;
 
 uses(RefreshDatabase::class);
@@ -192,6 +194,108 @@ XML;
         ['system' => 'provider.example/id', 'value' => 'series-0'],
         ['system' => null, 'value' => 'Unclassified 7'],
     ])->and($xpath->query('//programme[@channel="fallback-identity-channel"]/icon[@src="https://example.com/fallback-programme-artwork.jpg"]'))->toHaveCount(1);
+});
+
+test('xmlreader fallback reads the local SchedulesDirect XMLTV file when cache data is unavailable', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->create([
+        'dummy_epg' => false,
+    ]);
+    $epg = Epg::factory()->for($user)->create([
+        'source_type' => EpgSourceType::SCHEDULES_DIRECT,
+        'url' => null,
+        'uploads' => null,
+        'is_cached' => false,
+    ]);
+    $epgChannel = EpgChannel::factory()->for($user)->for($epg)->create([
+        'channel_id' => 'source.schedules-direct-fallback',
+        'display_name' => 'Schedules Direct Fallback Channel',
+        'lang' => 'en',
+    ]);
+
+    Channel::factory()->for($user)->for($playlist)->create([
+        'enabled' => true,
+        'is_vod' => false,
+        'epg_channel_id' => $epgChannel->id,
+        'stream_id' => 'schedules-direct-fallback-channel',
+        'title' => 'Schedules Direct Fallback Channel',
+        'channel' => 1,
+    ]);
+
+    $start = now()->startOfDay()->addHour()->format('YmdHis O');
+    $stop = now()->startOfDay()->addHours(2)->format('YmdHis O');
+    $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <programme start="{$start}" stop="{$stop}" channel="source.schedules-direct-fallback">
+    <title>Schedules Direct Fallback Programme</title>
+  </programme>
+</tv>
+XML;
+
+    Storage::disk('local')->put($epg->file_path, gzencode($xml));
+
+    $response = $this->get("/{$playlist->uuid}/epg.xml.gz");
+
+    $response->assertOk()->assertHeader('Content-Type', 'application/gzip');
+
+    $document = new DOMDocument;
+    expect($document->loadXML(gzdecode($response->getContent())))->toBeTrue();
+
+    $xpath = new DOMXPath($document);
+
+    expect($xpath->query('//programme[@channel="schedules-direct-fallback-channel"]/title[text()="Schedules Direct Fallback Programme"]'))->toHaveCount(1);
+});
+
+test('xmlreader fallback reports a missing local SchedulesDirect XMLTV file when cache data is unavailable', function () {
+    NotificationFacade::fake();
+
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->create([
+        'dummy_epg' => false,
+    ]);
+    $epg = Epg::factory()->for($user)->create([
+        'source_type' => EpgSourceType::SCHEDULES_DIRECT,
+        'url' => null,
+        'uploads' => null,
+        'is_cached' => false,
+    ]);
+    $epgChannel = EpgChannel::factory()->for($user)->for($epg)->create([
+        'channel_id' => 'source.schedules-direct-missing-file',
+        'display_name' => 'Schedules Direct Missing File Channel',
+        'lang' => 'en',
+    ]);
+
+    Channel::factory()->for($user)->for($playlist)->create([
+        'enabled' => true,
+        'is_vod' => false,
+        'epg_channel_id' => $epgChannel->id,
+        'stream_id' => 'schedules-direct-missing-file-channel',
+        'title' => 'Schedules Direct Missing File Channel',
+        'channel' => 1,
+    ]);
+
+    expect(Storage::disk('local')->missing($epg->file_path))->toBeTrue();
+
+    $response = $this->get("/{$playlist->uuid}/epg.xml.gz");
+
+    $response->assertOk()->assertHeader('Content-Type', 'application/gzip');
+
+    $document = new DOMDocument;
+    expect($document->loadXML(gzdecode($response->getContent())))->toBeTrue();
+
+    NotificationFacade::assertSentTo(
+        $user,
+        DatabaseNotification::class,
+        fn (DatabaseNotification $notification): bool => $notification->data['status'] === 'danger'
+            && $notification->data['title'] === "Error generating epg data for playlist \"{$playlist->name}\" using EPG \"{$epg->name}\""
+            && $notification->data['body'] === 'SchedulesDirect EPG source file is missing from local storage. Please sync the EPG and try again.',
+    );
+    NotificationFacade::assertNotSentTo(
+        $user,
+        DatabaseNotification::class,
+        fn (DatabaseNotification $notification): bool => $notification->data['body'] === 'Invalid EPG file. Unable to read or download an associated EPG file. Please check the URL or uploaded file and try again.',
+    );
 });
 
 test('epg xml generation preserves albanian characters with explicit utf8 escaping', function () {


### PR DESCRIPTION
## Summary

- resolve SchedulesDirect EPG fallback files from their model-derived local storage path
- report a specific missing-local-source message instead of the URL/upload-specific invalid-file message
- cover both existing and missing local XMLTV files through the productive playlist EPG endpoint

Fixes #1463

## Test plan

- `php artisan test --compact tests/Feature/EpgGenerateControllerTest.php --filter='xmlreader fallback'` (3 passed, 18 assertions)
- `php artisan test --compact tests/Feature/EpgGenerateControllerTest.php` (13 passed, 89 assertions)
- PostgreSQL 16 + Redis: `php artisan test --parallel --processes=4 --recreate-databases` (3,560 passed, 29 skipped, 11,850 assertions)
- `vendor/bin/pint --test`
- `vendor/bin/pint --dirty --format agent`
- targeted PHPStan for the two changed files (no errors)
- `composer audit --format=summary` (no advisories)
- `php artisan checkpoint:scan` (26 passed, 0 warnings, 0 failed)
- Node 20 with Safe-Chain: `npm ci`, `npm audit --audit-level=high`, `npm run build`
- PostgreSQL migration plus `php artisan plugins:discover` and `php artisan plugins:validate`
- `docker buildx build --load --platform linux/amd64 ...` (no push)

## Notes

A repository-wide level-0 PHPStan run reports 14 existing errors on both `upstream/dev` and this branch. Neither changed file reports a PHPStan error.
