### PR TITLE
fix(import): convert Xtream tv_archive_duration (days) to hours for shift

### DIFF
--- a/app/Jobs/ProcessM3uImport.php
+++ b/app/Jobs/ProcessM3uImport.php
@@ -679,7 +679,7 @@ class ProcessM3uImport implements ShouldQueue
                             'source_id' => $item->stream_id, // source ID for the channel
                             'channel' => $item->num ?? null,
                             'catchup' => $item->tv_archive ?? null,
-                            'shift' => $item->tv_archive_duration ?? 0,
+                            'shift' => (int) ($item->tv_archive_duration ?? 0) * 24,
                             // 'tvg_shift' => $item->tvg_shift ?? null, // @TODO: check if this is on Xtream API, not seeing it as a deffinition in the API docs
                         ];
                         if ($autoSort) {
@@ -980,10 +980,12 @@ class ProcessM3uImport implements ShouldQueue
                                     }
                                 }
 
-                                // Catch-up window (in hours, matching Xtream's tv_archive_duration).
-                                // Providers use different attributes for this: 'timeshift'/'tvg-shift' are
-                                // already in hours, while 'catchup-days'/'tvg-rec' express it in days.
-                                // Check in precedence order and stop at the first one present.
+                                // Catch-up window in hours. Providers use different attributes for this:
+                                // 'timeshift'/'tvg-shift' are already in hours, while 'catchup-days'/
+                                // 'tvg-rec' express it in days. Xtream's 'tv_archive_duration' is also
+                                // days (see XtreamApiController::resolveTvArchiveDuration, #1389) and is
+                                // converted days→hours at the Xtream ingest site. Check in precedence
+                                // order and stop at the first one present.
                                 foreach ([
                                     'timeshift' => 1,
                                     'tvg-shift' => 1,

--- a/tests/Feature/XtreamImportCatchupShiftTest.php
+++ b/tests/Feature/XtreamImportCatchupShiftTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * Regression tests for the Xtream import side of the "only one day of catchup"
+ * bug reported against m3u-tv.
+ *
+ * Root cause: Xtream's `tv_archive_duration` is days by ecosystem convention
+ * (asserted by this repo's own API docs at XtreamApiController.php:125-127 and
+ * since #1389 by resolveTvArchiveDuration at XtreamApiController.php:3474-3485,
+ * which converts hours→days). The Xtream import path stored the value raw
+ * into hours-denominated `shift`, so a provider advertising 7 (days) landed
+ * as `shift = 7` (hours) and surfaced to clients as ceil(7/24) = 1 day after
+ * #1389's correct export conversion. The fix multiplies by 24 at the ingest
+ * site, mirroring the `catchup-days`/`tvg-rec` M3U path at
+ * ProcessM3uImport.php:987-997 (covered separately by M3uImportCatchupShiftTest
+ * / #1317).
+ *
+ * Pairs with m3u-tv's `feat/catchup-channel-list-titles` dialog work (the
+ * one-day symptom was the client-side surface of this server-side bug).
+ */
+
+use App\Jobs\ProcessM3uImport;
+use App\Models\Job;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    $this->tempJobsDb = sys_get_temp_dir().'/jobs_test_'.uniqid().'.sqlite';
+    touch($this->tempJobsDb);
+    config(['database.connections.jobs.database' => $this->tempJobsDb]);
+    DB::purge('jobs');
+
+    $migration = require database_path('migrations/2025_02_13_215803_create_jobs_table.php');
+    $migration->up();
+});
+
+afterEach(function () {
+    DB::purge('jobs');
+    config(['database.connections.jobs.database' => database_path('jobs.sqlite')]);
+
+    if (isset($this->tempJobsDb) && file_exists($this->tempJobsDb)) {
+        @unlink($this->tempJobsDb);
+    }
+});
+
+/**
+ * Runs ProcessM3uImport against a faked Xtream playlist and returns the
+ * queued channel payload row. Mirrors the helper in
+ * M3uImportCatchupShiftTest.php:50-72.
+ *
+ * @param  int|string|null  $tvArchiveDuration  Wire-shape value to send
+ *                                              (int and string both occur in the wild; the fix must handle both
+ *                                              via the `(int)` cast).
+ * @return array<string, mixed>
+ */
+function xtreamImportedChannelPayloadRow(User $user, int|string|null $tvArchiveDuration): array
+{
+    $stream = [
+        'stream_id' => 1,
+        'name' => 'Catchup One',
+        'category_id' => '1',
+        'tv_archive' => 1,
+    ];
+    if ($tvArchiveDuration !== null) {
+        $stream['tv_archive_duration'] = $tvArchiveDuration;
+    }
+
+    $playlist = Playlist::withoutEvents(fn () => Playlist::factory()->for($user)->create([
+        'xtream' => true,
+        'xtream_config' => [
+            'url' => 'http://xtream.example.test:8080',
+            'username' => 'user',
+            'password' => 'pass',
+            'output' => 'ts',
+            'import_options' => ['live'],
+        ],
+        'import_prefs' => [],
+    ]));
+
+    Http::fake([
+        // Closure form is required because the import hits player_api.php
+        // with multiple actions (auth probe, get_live_categories,
+        // get_live_streams) — we need to switch on the action param.
+        'http://xtream.example.test:8080/player_api.php*' => function ($request) use ($stream) {
+            parse_str(parse_url($request->url(), PHP_URL_QUERY) ?? '', $query);
+            $action = $query['action'] ?? null;
+
+            return match ($action) {
+                'get_live_streams' => Http::response(json_encode([$stream]), 200),
+                'get_live_categories' => Http::response(json_encode([
+                    ['category_id' => '1', 'category_name' => 'News'],
+                ]), 200),
+                default => Http::response(
+                    json_encode(['user_info' => ['status' => 'Active']]),
+                    200
+                ),
+            };
+        },
+    ]);
+
+    Bus::fake();
+    (new ProcessM3uImport($playlist, force: true, isNew: true))->handle();
+
+    return Job::firstOrFail()->payload[0];
+}
+
+it('converts tv_archive_duration (int days) to hours when importing Xtream', function () {
+    $user = User::factory()->create();
+
+    $row = xtreamImportedChannelPayloadRow($user, 7);
+
+    expect((int) $row['shift'])->toBe(7 * 24);
+});
+
+it('converts tv_archive_duration (string days) to hours when importing Xtream', function () {
+    $user = User::factory()->create();
+
+    $row = xtreamImportedChannelPayloadRow($user, '3');
+
+    expect((int) $row['shift'])->toBe(3 * 24);
+});
+
+it('falls back to shift=0 when tv_archive_duration is absent', function () {
+    $user = User::factory()->create();
+
+    $row = xtreamImportedChannelPayloadRow($user, null);
+
+    expect((int) $row['shift'])->toBe(0);
+});


### PR DESCRIPTION
## Problem

Since #1389, every Xtream-sourced channel with provider catchup retention ≤ 24 days reports `tv_archive_duration = 1` to clients — users see **one day of catchup** regardless of what the provider offers (observed via m3u-tv, but affects any Xtream client, TiviMate included).

## Root cause

`Channel::$shift` is stored in **hours** (#1317 — the M3U attribute map converts `catchup-days`/`tvg-rec` ×24 accordingly). The Xtream API import path, however, stored the upstream provider's `tv_archive_duration` into `shift` **raw**:

```php
'shift' => $item->tv_archive_duration ?? 0,
```

That field is **days** by Xtream ecosystem convention — this repo's own `get_live_streams` docs assert exactly that since #1389. So a provider advertising 7 (days) landed as `shift = 7` (hours).

The bug was latent while the export echoed `shift` unconverted: clients read the raw value as days and happened to see the right number. #1389's (correct) `resolveTvArchiveDuration` added the hours→days conversion `ceil(shift / 24)` on export — and the mis-stored values collapsed: `ceil(7/24) = 1`.

## Fix

- Multiply by 24 at the Xtream ingest site, mirroring the M3U `catchup-days`/`tvg-rec` handling, with an `(int)` cast (providers send the field as a string as often as a number).
- Reword the M3U attribute-map comment that claimed `tv_archive_duration` is hours — it contradicted the export docs.
- No data migration: `shift` is already in the re-import upsert's update-column list, so existing channels self-heal on the next successful playlist sync.

The export side (`resolveTvArchiveDuration`) is deliberately untouched — it's correct. Providers that non-standardly send this field in hours would now over-report; unit-sniffing heuristics are left as a future product decision.

## Testing

New `tests/Feature/XtreamImportCatchupShiftTest.php` (3 cases: int days → ×24, string days → ×24 via the cast, absent → 0), exercising the real `get_live_streams` import leg against a faked Xtream API — companion to `M3uImportCatchupShiftTest` (#1317).

`pint --test` clean, new test 3/3, `M3uImportCatchupShiftTest` 5/5 and `ProcessM3uImportReimportTest` still green (11/11 combined), `composer security:scan` 26/26.

Verified end-to-end on a live instance: pre-fix DB values (`shift = 3` stored for 3-day channels) export as 1d; after a successful re-sync with this fix they land as `shift = 72` → reported 3d.