### PR TITLE
fix: correct filtered series sync progress

### DIFF
--- a/app/Jobs/ProcessM3uImport.php
+++ b/app/Jobs/ProcessM3uImport.php
@@ -1520,26 +1520,29 @@ class ProcessM3uImport implements ShouldQueue
         // FindReplace phase can see (and rewrite) series titles before STRM filenames are
         // generated. See SYNC_RUN_SUMMARY.md for full pipeline ordering rationale.
         if ($seriesCategories) {
-            $categoryCount = $seriesCategories->count();
-            $seriesCategories->each(function ($category, $index) use (&$jobs, $playlistId, $batchNo, $categoryCount) {
-                if (! $this->preprocess || $this->shouldIncludeSeries($category['category_name'] ?? '')) {
-                    // Check if category is auto-enabled
-                    $autoEnable = (bool) ($this->playlist->enable_series
-                        || $this->enabledCategories->contains($category['category_name'] ?? ''));
+            $seriesCategoriesToImport = $seriesCategories
+                ->filter(fn (array $category): bool => ! $this->preprocess
+                    || $this->shouldIncludeSeries($category['category_name'] ?? ''))
+                ->values();
+            $categoryCount = $seriesCategoriesToImport->count();
 
-                    // Create a job for each series category
-                    $jobs[] = new ProcessM3uImportSeriesChunk(
-                        [
-                            'categoryId' => $category['category_id'],
-                            'categoryName' => $category['category_name'],
-                            'playlistId' => $playlistId,
-                        ],
-                        $categoryCount,
-                        $batchNo,
-                        $index,
-                        $autoEnable
-                    );
-                }
+            $seriesCategoriesToImport->each(function (array $category, int $index) use (&$jobs, $playlistId, $batchNo, $categoryCount) {
+                // Check if category is auto-enabled
+                $autoEnable = (bool) ($this->playlist->enable_series
+                    || $this->enabledCategories->contains($category['category_name'] ?? ''));
+
+                // Create a job for each series category
+                $jobs[] = new ProcessM3uImportSeriesChunk(
+                    [
+                        'categoryId' => $category['category_id'],
+                        'categoryName' => $category['category_name'],
+                        'playlistId' => $playlistId,
+                    ],
+                    $categoryCount,
+                    $batchNo,
+                    $index,
+                    $autoEnable
+                );
             });
         }
 
@@ -1553,6 +1556,7 @@ class ProcessM3uImport implements ShouldQueue
             isNew: $this->isNew,
             runningLiveImport: $liveStreamsEnabled,
             runningVodImport: $vodStreamsEnabled,
+            runningSeriesImport: $seriesCategories !== null,
             syncRunId: $this->syncRunId,
         );
 

--- a/app/Jobs/ProcessM3uImport.php
+++ b/app/Jobs/ProcessM3uImport.php
@@ -575,7 +575,12 @@ class ProcessM3uImport implements ShouldQueue
 
                     return;
                 }
-                $seriesCategories = collect($seriesCategoriesResponse->json());
+                // Some panels return a 200 with malformed entries (null/scalar elements)
+                // mixed into the category list. Drop anything that isn't a category array so
+                // downstream loops and job builders can rely on the shape.
+                $seriesCategories = collect($seriesCategoriesResponse->json())
+                    ->filter(fn ($category): bool => is_array($category))
+                    ->values();
             } else {
                 $seriesCategories = null;
             }
@@ -1519,14 +1524,15 @@ class ProcessM3uImport implements ShouldQueue
         // exist in the DB by the time the SyncPipeline is built. This guarantees the
         // FindReplace phase can see (and rewrite) series titles before STRM filenames are
         // generated. See SYNC_RUN_SUMMARY.md for full pipeline ordering rationale.
+        $seriesCategoryCount = 0;
         if ($seriesCategories) {
             $seriesCategoriesToImport = $seriesCategories
-                ->filter(fn (array $category): bool => ! $this->preprocess
+                ->filter(fn ($category): bool => ! $this->preprocess
                     || $this->shouldIncludeSeries($category['category_name'] ?? ''))
                 ->values();
-            $categoryCount = $seriesCategoriesToImport->count();
+            $seriesCategoryCount = $seriesCategoriesToImport->count();
 
-            $seriesCategoriesToImport->each(function (array $category, int $index) use (&$jobs, $playlistId, $batchNo, $categoryCount) {
+            $seriesCategoriesToImport->each(function ($category, $index) use (&$jobs, $playlistId, $batchNo, $seriesCategoryCount) {
                 // Check if category is auto-enabled
                 $autoEnable = (bool) ($this->playlist->enable_series
                     || $this->enabledCategories->contains($category['category_name'] ?? ''));
@@ -1538,7 +1544,7 @@ class ProcessM3uImport implements ShouldQueue
                         'categoryName' => $category['category_name'],
                         'playlistId' => $playlistId,
                     ],
-                    $categoryCount,
+                    $seriesCategoryCount,
                     $batchNo,
                     $index,
                     $autoEnable
@@ -1556,7 +1562,11 @@ class ProcessM3uImport implements ShouldQueue
             isNew: $this->isNew,
             runningLiveImport: $liveStreamsEnabled,
             runningVodImport: $vodStreamsEnabled,
-            runningSeriesImport: $seriesCategories !== null,
+            // Only finalize series_progress at 100 when series categories were actually
+            // imported. A disabled series import, or an enabled one that resolved to zero
+            // selected/available categories, must leave series_progress at its start value
+            // (0) so the UI does not show a completed phase that never ran.
+            runningSeriesImport: $seriesCategoryCount > 0,
             syncRunId: $this->syncRunId,
         );
 

--- a/app/Jobs/ProcessM3uImportComplete.php
+++ b/app/Jobs/ProcessM3uImportComplete.php
@@ -28,6 +28,8 @@ class ProcessM3uImportComplete implements ShouldQueue
 {
     use Queueable;
 
+    public bool $runningSeriesImport = false;
+
     // Don't retry the job on failure
     public $tries = 1;
 
@@ -63,7 +65,10 @@ class ProcessM3uImportComplete implements ShouldQueue
         public bool $runningLiveImport = true, // Default to true for live imports
         public bool $runningVodImport = true, // Default to true for VOD imports
         public ?int $syncRunId = null,
+        bool $runningSeriesImport = false,
     ) {
+        $this->runningSeriesImport = $runningSeriesImport;
+
         // Set the invalidate import settings from config
         $this->invalidateImport = config('dev.invalidate_import', null);
         $this->invalidateImportThreshold = config('dev.invalidate_import_threshold', 100);
@@ -358,6 +363,9 @@ class ProcessM3uImportComplete implements ShouldQueue
         }
         if ($this->runningVodImport) {
             $update['vod_progress'] = 100; // Only set if VOD import was run
+        }
+        if ($this->runningSeriesImport) {
+            $update['series_progress'] = 100; // Only set if Series import was run
         }
         $playlist->update($update);
 

--- a/tests/Feature/SeriesImportFilteredProgressTest.php
+++ b/tests/Feature/SeriesImportFilteredProgressTest.php
@@ -58,6 +58,88 @@ it('calculates series progress from the filtered categories', function () {
         && $job->index === 0);
 });
 
+it('leaves series progress alone when no categories survive the filter', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::withoutEvents(fn (): Playlist => Playlist::factory()->for($user)->create([
+        'xtream' => true,
+        'enable_channels' => false,
+        'enable_vod_channels' => false,
+        'enable_series' => true,
+        'import_prefs' => [
+            'preprocess' => true,
+            'import_via_category' => true,
+            'selected_categories' => ['Not Offered By Provider'],
+            'included_vod_group_prefixes' => ['unused'],
+        ],
+        'xtream_config' => [
+            'url' => 'http://xtream.test',
+            'username' => 'user',
+            'password' => 'pass',
+            'import_options' => ['series'],
+        ],
+    ]));
+
+    Http::preventStrayRequests();
+    Http::fake([
+        '*action=get_series_categories*' => Http::response([
+            ['category_id' => 1, 'category_name' => 'Excluded Before'],
+            ['category_id' => 2, 'category_name' => 'Excluded After'],
+        ]),
+        '*player_api.php*' => Http::response([
+            'user_info' => ['auth' => 1],
+            'server_info' => [],
+        ]),
+    ]);
+    Bus::fake();
+
+    (new ProcessM3uImport($playlist, force: true))->handle();
+
+    expect($playlist->fresh()->errors)->toBeNull();
+    Bus::assertNotDispatched(ProcessM3uImportSeriesChunk::class);
+    Bus::assertChained([
+        fn (ProcessM3uImportComplete $job): bool => $job->runningSeriesImport === false,
+    ]);
+});
+
+it('skips malformed series category entries without failing the import', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::withoutEvents(fn (): Playlist => Playlist::factory()->for($user)->create([
+        'xtream' => true,
+        'enable_channels' => false,
+        'enable_vod_channels' => false,
+        'enable_series' => true,
+        'import_prefs' => [
+            'preprocess' => false,
+        ],
+        'xtream_config' => [
+            'url' => 'http://xtream.test',
+            'username' => 'user',
+            'password' => 'pass',
+            'import_options' => ['series'],
+        ],
+    ]));
+
+    Http::preventStrayRequests();
+    Http::fake([
+        '*action=get_series_categories*' => Http::response([
+            ['category_id' => 1, 'category_name' => 'Real Category'],
+            null,
+            false,
+        ]),
+        '*player_api.php*' => Http::response([
+            'user_info' => ['auth' => 1],
+            'server_info' => [],
+        ]),
+    ]);
+    Bus::fake();
+
+    (new ProcessM3uImport($playlist, force: true))->handle();
+
+    expect($playlist->fresh()->errors)->toBeNull();
+    Bus::assertDispatched(ProcessM3uImportSeriesChunk::class, fn (ProcessM3uImportSeriesChunk $job): bool => (int) $job->payload['categoryId'] === 1
+        && $job->batchCount === 1);
+});
+
 it('marks series progress complete when the series import finishes', function () {
     config(['dev.disable_sync_logs' => true]);
 

--- a/tests/Feature/SeriesImportFilteredProgressTest.php
+++ b/tests/Feature/SeriesImportFilteredProgressTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Jobs\ProcessM3uImport;
+use App\Jobs\ProcessM3uImportComplete;
+use App\Jobs\ProcessM3uImportSeriesChunk;
+use App\Models\Playlist;
+use App\Models\User;
+use App\Services\SyncPipelineService;
+use App\Settings\GeneralSettings;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+
+it('calculates series progress from the filtered categories', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::withoutEvents(fn (): Playlist => Playlist::factory()->for($user)->create([
+        'xtream' => true,
+        'enable_channels' => false,
+        'enable_vod_channels' => false,
+        'enable_series' => true,
+        'import_prefs' => [
+            'preprocess' => true,
+            'import_via_category' => true,
+            'selected_categories' => ['Selected Series'],
+            'included_vod_group_prefixes' => ['unused'],
+        ],
+        'xtream_config' => [
+            'url' => 'http://xtream.test',
+            'username' => 'user',
+            'password' => 'pass',
+            'import_options' => ['series'],
+        ],
+    ]));
+
+    Http::preventStrayRequests();
+    Http::fake([
+        '*action=get_series_categories*' => Http::response([
+            ['category_id' => 1, 'category_name' => 'Excluded Before'],
+            ['category_id' => 2, 'category_name' => 'Selected Series'],
+            ['category_id' => 3, 'category_name' => 'Excluded After'],
+        ]),
+        '*player_api.php*' => Http::response([
+            'user_info' => ['auth' => 1],
+            'server_info' => [],
+        ]),
+    ]);
+    Bus::fake();
+
+    (new ProcessM3uImport($playlist, force: true))->handle();
+
+    expect($playlist->fresh()->errors)->toBeNull();
+    Bus::assertChained([
+        ProcessM3uImportSeriesChunk::class,
+        fn (ProcessM3uImportComplete $job): bool => $job->runningSeriesImport,
+    ]);
+    Bus::assertDispatched(ProcessM3uImportSeriesChunk::class, fn (ProcessM3uImportSeriesChunk $job): bool => (int) $job->payload['categoryId'] === 2
+        && $job->batchCount === 1
+        && $job->index === 0);
+});
+
+it('marks series progress complete when the series import finishes', function () {
+    config(['dev.disable_sync_logs' => true]);
+
+    $settings = app(GeneralSettings::class);
+    $settings->suppress_success_notifications = true;
+    app()->instance(GeneralSettings::class, $settings);
+
+    $this->partialMock(SyncPipelineService::class, function ($mock) {
+        $mock->shouldReceive('startRun')->andReturnNull();
+        $mock->shouldReceive('expandPipelineAfterImport')->andReturnNull();
+        $mock->shouldReceive('completePhase')->andReturnNull();
+    });
+
+    $user = User::factory()->create();
+    $playlist = Playlist::withoutEvents(fn (): Playlist => Playlist::factory()->for($user)->create([
+        'series_progress' => 59,
+    ]));
+
+    (new ProcessM3uImportComplete(
+        userId: $user->id,
+        playlistId: $playlist->id,
+        batchNo: 'series-progress-batch',
+        start: Carbon::now()->subMinute(),
+        runningLiveImport: false,
+        runningVodImport: false,
+        runningSeriesImport: true,
+    ))->handle($settings);
+
+    expect($playlist->fresh()->series_progress)->toEqual(100);
+});


### PR DESCRIPTION
 ## Summary

  Fix the series synchronization progress calculation when category prefilters are enabled.

  Series categories are now filtered and reindexed before calculating the batch size and dispatching category jobs, matching the approach already used by the VOD synchronization flow.

  The series progress is also explicitly finalized at 100% when the import completes.

  ## Root cause

  The series sync calculated its progress using the total number and original indexes of all provider categories, including categories excluded by the configured prefilters.

  For example, if the selected categories ended around index 137 out of 231 provider categories, the final reported progress was approximately 59%, even though every selected category had already been processed.

  The original index also prevented the last selected category from being recognized as the final series batch.

  VOD sync was not affected because it filters the categories before calculating the total and dispatching its jobs.

  ## Changes

  - Filter series categories before calculating the batch total.
  - Reindex the filtered category collection before dispatching jobs.
  - Mark completed series imports at 100%.
  - Preserve compatibility with already serialized completion jobs.
  - Add regression coverage using a minimal filtered-category scenario.

  ## Testing

  - Full CI workflow: 2,827 tests passed, 9,820 assertions.
  - Regression tests: 2 tests passed, 5 assertions.
  - Laravel Pint passed.
  - Docker build and frontend build passed.
  - PostgreSQL migrations passed.
  - Composer and npm security audits passed.
  - Checkpoint security scan passed.
  - Plugin validation passed.