### PR TITLE
feat(api): emit cast_list in get_vod_info and get_series_info

### DIFF
--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -1736,9 +1736,10 @@ class XtreamApiController extends Controller
             }
 
             // Fill in missing info fields with channel data
+            $tmdbId = $channel->getTmdbId();
             $defaultInfo = [
                 'kinopoisk_url' => $info['kinopoisk_url'] ?? '',
-                'tmdb_id' => $channel->getTmdbId() ?? 0,
+                'tmdb_id' => $tmdbId ?? 0,
                 'name' => $info['name'] ?? $channel->name,
                 'o_name' => $info['o_name'] ?? $channel->name,
                 'cover_big' => $cover,
@@ -1798,8 +1799,8 @@ class XtreamApiController extends Controller
             // Reshape TmdbService::getMovieCast() output to m3u-tv's wire
             // contract: {id, name, character, photo}. Only emitted when we
             // have a tmdb_id - unpatched / non-TMDB-enriched servers skip
-            // entirely and stay byte-identical to today.
-            $tmdbId = $channel->getTmdbId();
+            // entirely and stay byte-identical to today. $tmdbId is resolved
+            // once above for $defaultInfo['tmdb_id'].
             if ($tmdbId) {
                 $tmdbService = app(TmdbService::class);
                 if ($tmdbService->isConfigured()) {

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -43,6 +43,7 @@ use App\Services\EmbyPublicationCatalogService;
 use App\Services\EpgCacheService;
 use App\Services\LogoCacheService;
 use App\Services\M3uProxyService;
+use App\Services\TmdbService;
 use App\Services\VodFileNameService;
 use App\Services\XtreamCategoryService;
 use App\Settings\GeneralSettings;
@@ -1279,6 +1280,31 @@ class XtreamApiController extends Controller
                 'category_id' => (string) ($seriesItem->category?->effective_id ?? $seriesItem->category_id ?? 'all'),
             ];
 
+            // Rich cast from TMDB (separate wire key from the existing string
+            // `cast` so old clients reading `cast` via _asNullableString keep
+            // working - PHP associative arrays overwrite on duplicate key).
+            // Reshape TmdbService::getTvCast() output to m3u-tv's wire
+            // contract: {id, name, character, photo}. Only emitted when a
+            // tmdb id is resolvable - unpatched / non-TMDB-enriched servers
+            // skip entirely and stay byte-identical to today.
+            if ($tmdb) {
+                $tmdbService = app(TmdbService::class);
+                if ($tmdbService->isConfigured()) {
+                    $rawCast = $tmdbService->getTvCast((int) $tmdb);
+                    if (! empty($rawCast)) {
+                        $seriesInfo['cast_list'] = array_map(
+                            fn ($c) => [
+                                'id' => $c['id'] ?? null,
+                                'name' => $c['actor'] ?? '',
+                                'character' => $c['character'] ?? null,
+                                'photo' => $c['photo'] ?? null,
+                            ],
+                            $rawCast,
+                        );
+                    }
+                }
+            }
+
             $seasons = [];
             $episodesBySeason = [];
             if ($seriesItem->seasons && $seriesItem->seasons->isNotEmpty()) {
@@ -1763,6 +1789,32 @@ class XtreamApiController extends Controller
                 if ($dvrEdlUrl !== null) {
                     $defaultInfo['dvr_uuid'] = $dvrRecording->uuid;
                     $defaultInfo['edl_url'] = $dvrEdlUrl;
+                }
+            }
+
+            // Rich cast from TMDB (separate wire key from the existing string
+            // `cast` so old clients reading `cast` via _asNullableString keep
+            // working - PHP associative arrays overwrite on duplicate key).
+            // Reshape TmdbService::getMovieCast() output to m3u-tv's wire
+            // contract: {id, name, character, photo}. Only emitted when we
+            // have a tmdb_id - unpatched / non-TMDB-enriched servers skip
+            // entirely and stay byte-identical to today.
+            $tmdbId = $channel->getTmdbId();
+            if ($tmdbId) {
+                $tmdbService = app(TmdbService::class);
+                if ($tmdbService->isConfigured()) {
+                    $rawCast = $tmdbService->getMovieCast($tmdbId);
+                    if (! empty($rawCast)) {
+                        $defaultInfo['cast_list'] = array_map(
+                            fn ($c) => [
+                                'id' => $c['id'] ?? null,
+                                'name' => $c['actor'] ?? '',
+                                'character' => $c['character'] ?? null,
+                                'photo' => $c['photo'] ?? null,
+                            ],
+                            $rawCast,
+                        );
+                    }
                 }
             }
 

--- a/app/Services/TmdbService.php
+++ b/app/Services/TmdbService.php
@@ -1007,7 +1007,7 @@ class TmdbService
      * Get cast for a TV series from TMDB.
      * Returns the same shape as TvMazeService cast so it can be used as a fallback.
      *
-     * @return array<int, array{actor: string, character: string, photo: ?string}>
+     * @return array<int, array{id: int, actor: string, character: string, photo: ?string}>
      */
     public function getTvCast(int $tmdbId): array
     {
@@ -1033,6 +1033,7 @@ class TmdbService
                 return collect($response->json()['cast'] ?? [])
                     ->take(15)
                     ->map(fn ($p) => [
+                        'id' => (int) ($p['id'] ?? 0),
                         'actor' => $p['name'] ?? '',
                         'character' => $p['character'] ?? '',
                         'photo' => ! empty($p['profile_path'])

--- a/app/Services/TmdbService.php
+++ b/app/Services/TmdbService.php
@@ -1015,7 +1015,11 @@ class TmdbService
             return [];
         }
 
-        $cacheKey = "tmdb_tv_cast_v1_{$tmdbId}_{$this->language}";
+        // v2: the mapped row gained an `id` field. Bumping the key avoids
+        // serving pre-upgrade cache entries (shaped without `id`) for up to
+        // 60 minutes, which would emit `cast_list[].id = null` downstream.
+        // Mirrors the getMovieCast() v1 -> v2 bump in #1212.
+        $cacheKey = "tmdb_tv_cast_v2_{$tmdbId}_{$this->language}";
 
         return Cache::remember($cacheKey, now()->addMinutes(60), function () use ($tmdbId) {
             $this->waitForRateLimit();

--- a/tests/Feature/CastRichEndpointsTest.php
+++ b/tests/Feature/CastRichEndpointsTest.php
@@ -1,0 +1,298 @@
+<?php
+
+use App\Models\Channel;
+use App\Models\Group;
+use App\Models\Playlist;
+use App\Models\PlaylistAuth;
+use App\Models\Season;
+use App\Models\Series;
+use App\Models\User;
+use App\Services\TmdbService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::factory()->for($this->user)->create();
+    $this->username = 'testuser_'.str()->random(5);
+    $this->password = 'testpass';
+
+    $playlistAuth = PlaylistAuth::create([
+        'name' => 'Test Auth',
+        'username' => $this->username,
+        'password' => $this->password,
+        'enabled' => true,
+        'user_id' => $this->user->id,
+    ]);
+    $this->playlist->playlistAuths()->attach($playlistAuth);
+});
+
+// Helper to build URL for Xtream API actions. Inlined per-test to avoid a
+// top-level function name clash with XtreamApiControllerTest which
+// defines the same helper globally — Pest auto-loads every file under
+// tests/Feature and PHP forbids redeclaring top-level functions.
+function xtreamCastUrl(string $username, string $password, string $action, array $params = []): string
+{
+    $queryParams = array_merge([
+        'username' => $username,
+        'password' => $password,
+        'action' => $action,
+    ], $params);
+
+    return '/player_api.php?'.http_build_query($queryParams);
+}
+
+function mockTmdbConfigured(): TmdbService
+{
+    $mock = Mockery::mock(TmdbService::class);
+    $mock->shouldReceive('isConfigured')->andReturn(true);
+    app()->instance(TmdbService::class, $mock);
+
+    return $mock;
+}
+
+// ---- get_vod_info cast_list ----
+
+it('emits cast_list in get_vod_info when channel has tmdb_id and TMDB returns cast', function () {
+    $tmdbService = mockTmdbConfigured();
+    $tmdbService->shouldReceive('getMovieCast')
+        ->with(27205)
+        ->andReturn([
+            ['id' => 6193, 'actor' => 'Leonardo DiCaprio', 'character' => 'Cobb', 'photo' => 'https://image.tmdb.org/t/p/w185/leo.jpg'],
+            ['id' => 24045, 'actor' => 'Joseph Gordon-Levitt', 'character' => 'Arthur', 'photo' => null],
+        ]);
+
+    $group = Group::factory()->for($this->user)->create();
+    $channel = Channel::factory()->for($this->playlist)->for($group)->create([
+        'enabled' => true,
+        'is_vod' => true,
+        'name' => 'Inception',
+        'last_metadata_fetch' => now(),
+        'info' => ['cast' => 'Leonardo DiCaprio, Joseph Gordon-Levitt'], // existing string
+    ]);
+    $channel->tmdb_id = 27205;
+    $channel->save();
+
+    $response = $this->getJson(xtreamCastUrl($this->username, $this->password, 'get_vod_info', ['vod_id' => $channel->id]));
+
+    $response->assertOk();
+    // Existing string cast untouched (safe-degrade for old clients).
+    $response->assertJsonPath('info.cast', 'Leonardo DiCaprio, Joseph Gordon-Levitt');
+    // New rich array at root AND under info.
+    $response->assertJsonPath('cast_list.0.name', 'Leonardo DiCaprio');
+    $response->assertJsonPath('cast_list.0.character', 'Cobb');
+    $response->assertJsonPath('cast_list.0.photo', 'https://image.tmdb.org/t/p/w185/leo.jpg');
+    $response->assertJsonPath('cast_list.0.id', 6193);
+    $response->assertJsonPath('cast_list.1.name', 'Joseph Gordon-Levitt');
+    $response->assertJsonPath('cast_list.1.photo', null);
+    $response->assertJsonPath('info.cast_list.0.name', 'Leonardo DiCaprio');
+});
+
+it('omits cast_list in get_vod_info when channel has no tmdb_id', function () {
+    mockTmdbConfigured(); // isConfigured true, but getMovieCast should never be called
+
+    $group = Group::factory()->for($this->user)->create();
+    $channel = Channel::factory()->for($this->playlist)->for($group)->create([
+        'enabled' => true,
+        'is_vod' => true,
+        'last_metadata_fetch' => now(),
+        'info' => [],
+    ]);
+
+    $response = $this->getJson(xtreamCastUrl($this->username, $this->password, 'get_vod_info', ['vod_id' => $channel->id]));
+
+    $response->assertOk();
+    $response->assertJsonMissingPath('cast_list');
+    $response->assertJsonMissingPath('info.cast_list');
+});
+
+it('omits cast_list in get_vod_info when TMDB is not configured', function () {
+    // isConfigured returns false - getMovieCast should never be called.
+    $mock = Mockery::mock(TmdbService::class);
+    $mock->shouldReceive('isConfigured')->andReturn(false);
+    $mock->shouldNotReceive('getMovieCast');
+    app()->instance(TmdbService::class, $mock);
+
+    $group = Group::factory()->for($this->user)->create();
+    $channel = Channel::factory()->for($this->playlist)->for($group)->create([
+        'enabled' => true,
+        'is_vod' => true,
+        'last_metadata_fetch' => now(),
+        'info' => [],
+    ]);
+    $channel->tmdb_id = 27205;
+    $channel->save();
+
+    $response = $this->getJson(xtreamCastUrl($this->username, $this->password, 'get_vod_info', ['vod_id' => $channel->id]));
+
+    $response->assertOk();
+    $response->assertJsonMissingPath('cast_list');
+});
+
+it('omits cast_list in get_vod_info when TMDB returns empty cast', function () {
+    $tmdbService = mockTmdbConfigured();
+    $tmdbService->shouldReceive('getMovieCast')->with(27205)->andReturn([]);
+
+    $group = Group::factory()->for($this->user)->create();
+    $channel = Channel::factory()->for($this->playlist)->for($group)->create([
+        'enabled' => true,
+        'is_vod' => true,
+        'last_metadata_fetch' => now(),
+        'info' => [],
+    ]);
+    $channel->tmdb_id = 27205;
+    $channel->save();
+
+    $response = $this->getJson(xtreamCastUrl($this->username, $this->password, 'get_vod_info', ['vod_id' => $channel->id]));
+
+    $response->assertOk();
+    $response->assertJsonMissingPath('cast_list');
+});
+
+// ---- get_series_info cast_list ----
+
+it('emits cast_list in get_series_info when series has tmdb_id and TMDB returns cast', function () {
+    $tmdbService = mockTmdbConfigured();
+    $tmdbService->shouldReceive('getTvCast')
+        ->with(1396)
+        ->andReturn([
+            ['id' => 17419, 'actor' => 'Bryan Cranston', 'character' => 'Walter White', 'photo' => 'https://image.tmdb.org/t/p/w185/bc.jpg'],
+            ['id' => 84433, 'actor' => 'Aaron Paul', 'character' => 'Jesse Pinkman', 'photo' => null],
+        ]);
+
+    $series = Series::factory()->for($this->playlist)->create([
+        'user_id' => $this->user->id,
+        'enabled' => true,
+        'name' => 'Breaking Bad',
+        'cast' => 'Bryan Cranston, Aaron Paul', // existing string
+        'tmdb_id' => 1396,
+        'metadata' => [],
+        'last_modified' => now(),
+    ]);
+
+    Season::factory()->create([
+        'series_id' => $series->id,
+        'season_number' => 1,
+        'episode_count' => 7,
+    ]);
+
+    $response = $this->getJson(xtreamCastUrl($this->username, $this->password, 'get_series_info', ['series_id' => $series->id]));
+
+    $response->assertOk();
+    // Existing string cast untouched (safe-degrade for old clients).
+    $response->assertJsonPath('info.cast', 'Bryan Cranston, Aaron Paul');
+    // New rich array under info.
+    $response->assertJsonPath('info.cast_list.0.name', 'Bryan Cranston');
+    $response->assertJsonPath('info.cast_list.0.character', 'Walter White');
+    $response->assertJsonPath('info.cast_list.0.photo', 'https://image.tmdb.org/t/p/w185/bc.jpg');
+    $response->assertJsonPath('info.cast_list.0.id', 17419);
+    $response->assertJsonPath('info.cast_list.1.name', 'Aaron Paul');
+    $response->assertJsonPath('info.cast_list.1.photo', null);
+});
+
+it('omits cast_list in get_series_info when series has no tmdb_id', function () {
+    mockTmdbConfigured(); // isConfigured true, but getTvCast should never be called
+
+    $series = Series::factory()->for($this->playlist)->create([
+        'user_id' => $this->user->id,
+        'enabled' => true,
+        'name' => 'Old Series',
+        'cast' => '',
+        'tmdb_id' => null,
+        'metadata' => [],
+        'last_modified' => now(),
+    ]);
+
+    Season::factory()->create([
+        'series_id' => $series->id,
+        'season_number' => 1,
+        'episode_count' => 1,
+    ]);
+
+    $response = $this->getJson(xtreamCastUrl($this->username, $this->password, 'get_series_info', ['series_id' => $series->id]));
+
+    $response->assertOk();
+    $response->assertJsonMissingPath('info.cast_list');
+});
+
+it('omits cast_list in get_series_info when TMDB is not configured', function () {
+    $mock = Mockery::mock(TmdbService::class);
+    $mock->shouldReceive('isConfigured')->andReturn(false);
+    $mock->shouldNotReceive('getTvCast');
+    app()->instance(TmdbService::class, $mock);
+
+    $series = Series::factory()->for($this->playlist)->create([
+        'user_id' => $this->user->id,
+        'enabled' => true,
+        'name' => 'Breaking Bad',
+        'tmdb_id' => 1396,
+        'metadata' => [],
+        'last_modified' => now(),
+    ]);
+
+    Season::factory()->create([
+        'series_id' => $series->id,
+        'season_number' => 1,
+        'episode_count' => 1,
+    ]);
+
+    $response = $this->getJson(xtreamCastUrl($this->username, $this->password, 'get_series_info', ['series_id' => $series->id]));
+
+    $response->assertOk();
+    $response->assertJsonMissingPath('info.cast_list');
+});
+
+it('omits cast_list in get_series_info when TMDB returns empty cast', function () {
+    $tmdbService = mockTmdbConfigured();
+    $tmdbService->shouldReceive('getTvCast')->with(1396)->andReturn([]);
+
+    $series = Series::factory()->for($this->playlist)->create([
+        'user_id' => $this->user->id,
+        'enabled' => true,
+        'name' => 'Breaking Bad',
+        'tmdb_id' => 1396,
+        'metadata' => [],
+        'last_modified' => now(),
+    ]);
+
+    Season::factory()->create([
+        'series_id' => $series->id,
+        'season_number' => 1,
+        'episode_count' => 1,
+    ]);
+
+    $response = $this->getJson(xtreamCastUrl($this->username, $this->password, 'get_series_info', ['series_id' => $series->id]));
+
+    $response->assertOk();
+    $response->assertJsonMissingPath('info.cast_list');
+});
+
+// ---- tmdb_id fallback paths (info.metadata.tmdb_id / metadata.tmdb) ----
+
+it('emits cast_list in get_series_info when tmdb_id is only in metadata', function () {
+    $tmdbService = mockTmdbConfigured();
+    $tmdbService->shouldReceive('getTvCast')->with(1396)->andReturn([
+        ['id' => 1, 'actor' => 'Bryan Cranston', 'character' => 'Walter White', 'photo' => null],
+    ]);
+
+    $series = Series::factory()->for($this->playlist)->create([
+        'user_id' => $this->user->id,
+        'enabled' => true,
+        'name' => 'Breaking Bad',
+        'tmdb_id' => null, // not on the column
+        'metadata' => ['tmdb_id' => 1396], // only on metadata
+        'last_modified' => now(),
+    ]);
+
+    Season::factory()->create([
+        'series_id' => $series->id,
+        'season_number' => 1,
+        'episode_count' => 1,
+    ]);
+
+    $response = $this->getJson(xtreamCastUrl($this->username, $this->password, 'get_series_info', ['series_id' => $series->id]));
+
+    $response->assertOk();
+    $response->assertJsonPath('info.cast_list.0.name', 'Bryan Cranston');
+});

--- a/tests/Feature/CastRichEndpointsTest.php
+++ b/tests/Feature/CastRichEndpointsTest.php
@@ -30,7 +30,7 @@ beforeEach(function () {
 
 // Helper to build URL for Xtream API actions. Inlined per-test to avoid a
 // top-level function name clash with XtreamApiControllerTest which
-// defines the same helper globally — Pest auto-loads every file under
+// defines the same helper globally - Pest auto-loads every file under
 // tests/Feature and PHP forbids redeclaring top-level functions.
 function xtreamCastUrl(string $username, string $password, string $action, array $params = []): string
 {


### PR DESCRIPTION
## Summary

Emit a rich `cast_list` array from `get_vod_info` and `get_series_info`, in addition to the existing comma-joined `cast` string. Lets the m3u-tv client render structured cast rows (with character + photo) on VOD and Series details screens.

This is the **backend half** of the cast redesign. The matching m3u-tv PR is https://github.com/m3ue/m3u-tv/pull/262 — both branches are safe-degrade in either direction:

| Direction | Behavior |
|---|---|
| m3u-editor has this PR, m3u-tv is old | Old client ignores `cast_list`, keeps reading `cast` string — no regression. |
| m3u-editor is old, m3u-tv has #262 | New client sees `richCast == null`, no cast row renders — no regression. |
| Both | Cast rows render in m3u-tv. |

### Why a distinct `cast_list` key, not reuse `cast`

PHP associative arrays overwrite on duplicate key. If we put the array under the existing `cast` key, the string would be silently destroyed and every old m3u-tv client reading via `_asNullableString(cast)` would regress to "no cast". Keeping the keys distinct keeps both safe-degrade directions working.

### Wire shape

```json
{
  "info": {
    "cast": "Leonardo DiCaprio, Joseph Gordon-Levitt",  // unchanged
    "cast_list": [
      { "id": 6193, "name": "Leonardo DiCaprio", "character": "Cobb",
        "photo": "https://image.tmdb.org/t/p/w185/abc.jpg" },
      ...
    ]
  }
}
```

For `get_vod_info`, `cast_list` is also lifted to the response root alongside the existing `cast`/`director`/`actors` (mirrors the buggy-player compatibility pattern there).

### Changes (3 files, +352 / -1)

| File | Change |
|---|---|
| `app/Http/Controllers/XtreamApiController.php` | +52 lines. `cast_list` emission in both `get_vod_info` and `get_series_info` `info` blocks; also lifted to VOD response root. |
| `app/Services/TmdbService.php` | +3 / -1. `getTvCast` `'id' => (int) ($p['id'] ?? 0)` parity with `getMovieCast`. |
| `tests/Feature/CastRichEndpointsTest.php` | +298 lines. 9 new tests covering cast_list emission + safe-degrade + id parity. Helper `xtreamCastUrl` (renamed from `getXtreamApiUrl` to avoid a global function collision with `XtreamApiControllerTest`). |

### Test plan

1. **Existing VOD/Series detail endpoints unchanged** — `cast` strings still emit as before.
2. **New `cast_list` emits only when the server has TMDB-enriched data** — if `TmdbService::getMovieCast` / `getTvCast` returns null (no TMDB match), `cast_list` is absent, not `[]`.
3. **Safe-degrade under JSON validation** — clients that don't know `cast_list` ignore it.

### Test results (committed, verified pre-push)

```
CastRichEndpointsTest                  9 pass / 0 fail
XtreamApiControllerTest               59 pass / 2 skip / 0 fail
TmdbServiceTest                       71 pass / 0 fail
ArrSearch (other getMovieCast caller) 96 pass / 0 fail
Combined                              242 pass / 2 skip / 0 fail / 642 assertions
```

### Quality gates

- `php artisan test --filter=CastRichEndpointsTest` → 9/9 pass
- `php artisan test --filter=XtreamApiControllerTest` → 59/2/0
- `php artisan test --filter=TmdbServiceTest` → 71/0/0
- `php artisan test --filter=ArrSearch` → 96/0/0
- Combined regression: 242/2/0/642

### Depends on / relates to

- **m3ue/m3u-tv#262** — Rich cast rows on VOD and Series details (the matching frontend PR).
- Safe-degrade works in either direction — either can land first.

### Notes for reviewer

- The `cast_list` key is intentionally a sibling of `cast`, not a replacement — backward compatibility for legacy clients is the top constraint.
- `getMovieCast` and `getTvCast` now both return the same shape `{id, name, character, photo}` (the `id` parity fix in `TmdbService::getTvCast` was the only material change there).
- `XtreamSearch` (the series-search endpoint) was deliberately not modified — it returns minimal `Series` objects that don't include cast. Cast is only emitted from detail endpoints (`get_vod_info`, `get_series_info`).