### PR TITLE
feat: add optional title similarity guard to channel merging

### DIFF
--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -8,6 +8,7 @@ use App\Models\Group;
 use App\Models\Playlist;
 use App\Models\User;
 use App\Services\ChannelMergeKeyService;
+use App\Services\ChannelTitleSimilarityService;
 use Filament\Notifications\Notification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -82,6 +83,7 @@ class MergeChannels implements ShouldQueue
         public string $contentType = 'live',
         public string $mergeKey = 'stream_id',
         public bool $scrubberAwareMasterSelection = false,
+        public float $minTitleSimilarity = 0.0,
     ) {
         $this->contentType = in_array($this->contentType, ['live', 'vod'], true) ? $this->contentType : 'live';
         $this->mergeKey = in_array($this->mergeKey, ['stream_id', 'tmdb_id'], true) ? $this->mergeKey : 'stream_id';
@@ -89,6 +91,10 @@ class MergeChannels implements ShouldQueue
         if ($this->contentType !== 'vod' && $this->mergeKey === 'tmdb_id') {
             $this->mergeKey = 'stream_id';
         }
+
+        // Clamp to a sane range. 0.0 keeps the guard off, which is the default
+        // so existing merges behave exactly as before.
+        $this->minTitleSimilarity = max(0.0, min(1.0, $this->minTitleSimilarity));
     }
 
     /**
@@ -550,6 +556,11 @@ class MergeChannels implements ShouldQueue
      * master's - a failover pointing at the exact same stream the master
      * already plays provides no redundancy, it's just a no-op duplicate.
      */
+    /**
+     * Drop failover candidates that would be useless or actively wrong:
+     * anything pointing at the master's own URL, and — when enabled — anything
+     * whose title says it is a different channel.
+     */
     protected function filterFailoverCandidates(Collection $group, Channel $master): Collection
     {
         $masterUrl = $this->resolveEffectiveUrl($master);
@@ -558,9 +569,36 @@ class MergeChannels implements ShouldQueue
             return $group;
         }
 
-        return $group->filter(function (Channel $channel) use ($masterUrl) {
-            return $this->resolveEffectiveUrl($channel) !== $masterUrl;
+        return $group->filter(function (Channel $channel) use ($masterUrl, $master) {
+            if ($this->resolveEffectiveUrl($channel) === $masterUrl) {
+                return false;
+            }
+
+            return $this->titlesArePlausiblyTheSameChannel($master, $channel);
         });
+    }
+
+    /**
+     * Guard against a bad merge key turning unrelated channels into each
+     * other's failovers.
+     *
+     * Merging trusts its grouping key completely, so one wrong stream ID —
+     * whether the provider sent it or the importer mis-parsed it — is enough to
+     * make a viewer's channel fail over to something entirely different. When
+     * minTitleSimilarity is set, the titles have to agree as well as the key.
+     *
+     * Off by default (0.0), and the comparison abstains whenever it cannot
+     * judge safely, so turning it on only ever drops pairs it is confident
+     * about.
+     */
+    protected function titlesArePlausiblyTheSameChannel(Channel $master, Channel $candidate): bool
+    {
+        if ($this->minTitleSimilarity <= 0.0) {
+            return true;
+        }
+
+        return app(ChannelTitleSimilarityService::class)
+            ->isPlausibleMatch($master, $candidate, $this->minTitleSimilarity);
     }
 
     /**

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -565,12 +565,13 @@ class MergeChannels implements ShouldQueue
     {
         $masterUrl = $this->resolveEffectiveUrl($master);
 
-        if ($masterUrl === null) {
-            return $group;
-        }
-
         return $group->filter(function (Channel $channel) use ($masterUrl, $master) {
-            if ($this->resolveEffectiveUrl($channel) === $masterUrl) {
+            // A master with no URL has nothing to compare against, so the
+            // duplicate-URL check is skipped for it - but the title guard still
+            // has to run. Returning the whole group early here let every
+            // candidate through whenever the master's URL was empty, which
+            // silently disabled the guard for exactly those records.
+            if ($masterUrl !== null && $this->resolveEffectiveUrl($channel) === $masterUrl) {
                 return false;
             }
 
@@ -593,12 +594,17 @@ class MergeChannels implements ShouldQueue
      */
     protected function titlesArePlausiblyTheSameChannel(Channel $master, Channel $candidate): bool
     {
-        if ($this->minTitleSimilarity <= 0.0) {
+        // A job queued before this property existed unserialises without it,
+        // and reading an uninitialised typed property is a fatal error. Treat a
+        // missing value as the default, so old payloads drain normally.
+        $threshold = isset($this->minTitleSimilarity) ? $this->minTitleSimilarity : 0.0;
+
+        if ($threshold <= 0.0) {
             return true;
         }
 
         return app(ChannelTitleSimilarityService::class)
-            ->isPlausibleMatch($master, $candidate, $this->minTitleSimilarity);
+            ->isPlausibleMatch($master, $candidate, $threshold);
     }
 
     /**

--- a/app/Services/ChannelTitleSimilarityService.php
+++ b/app/Services/ChannelTitleSimilarityService.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Channel;
+
+/**
+ * Compares two channel titles to decide whether they plausibly describe the
+ * same channel.
+ *
+ * This exists because merging trusts its grouping key completely. When a
+ * provider hands over a bad stream ID — or the importer mis-parses one — every
+ * channel sharing that key is treated as the same channel, and unrelated
+ * channels end up as each other's failovers. A viewer whose channel drops then
+ * gets something entirely different.
+ *
+ * Comparing the raw titles does not work. Provider titles carry a source
+ * prefix and a pile of quality decorations, and those dominate the comparison:
+ * "DE| SYFY HEVC" and "DE| SYFY FHD" are the same channel but share little
+ * literal text. So titles are reduced to a bare core name first, and only
+ * those cores are compared.
+ */
+class ChannelTitleSimilarityService
+{
+    /**
+     * Quality, format and source tokens that say nothing about channel identity.
+     */
+    private const NOISE_TOKENS = [
+        'fhd', 'uhd', 'hd', 'sd', 'hq', 'lq', '4k', '8k', '1080p', '720p', '576p', '480p',
+        'hevc', 'h265', 'h264', 'x265', 'x264', 'raw', 'ts', 'm3u8', 'mpegts',
+        'vip', 'backup', 'alt', 'multi', 'plus1', 'live',
+    ];
+
+    /**
+     * Superscript and decorative characters providers use as quality markers,
+     * e.g. "UK: BBC ONE ᴴᴰ ◉" or "VIP: SKY SPORTS F1 ⁴ᵏ".
+     */
+    private const DECORATIONS = [
+        'ᴴ', 'ᴰ', 'ᴿ', 'ᴬ', 'ᵂ', 'ʰ', 'ᵉ', 'ᵛ', 'ᶜ', 'ᵁ', 'ᴾ', 'ᶠ', 'ˢ',
+        '⁴', 'ᵏ', '³', '⁸', '⁰', '⁵', '¹', '²', '◉', '★', '☆', '⚽', '●',
+    ];
+
+    /**
+     * Core names shorter than this can't be compared meaningfully — "E!" reduces
+     * to "e", and a one-character string scores near zero against anything.
+     * Below this length the guard abstains rather than guessing.
+     */
+    private const MIN_COMPARABLE_LENGTH = 5;
+
+    /**
+     * Decide whether a failover candidate plausibly describes the same channel
+     * as its master.
+     *
+     * Abstains (returns true) whenever it cannot judge safely, so enabling the
+     * guard can only ever remove pairs it is confident about.
+     *
+     * @param  float  $threshold  0.0 disables the check entirely.
+     */
+    public function isPlausibleMatch(Channel $master, Channel $candidate, float $threshold): bool
+    {
+        if ($threshold <= 0.0) {
+            return true;
+        }
+
+        return $this->titlesMatch(
+            $this->effectiveTitle($master),
+            $this->effectiveTitle($candidate),
+            $threshold,
+        );
+    }
+
+    /**
+     * Compare two raw provider titles.
+     */
+    public function titlesMatch(?string $masterTitle, ?string $candidateTitle, float $threshold): bool
+    {
+        if ($threshold <= 0.0) {
+            return true;
+        }
+
+        $master = $this->coreName($masterTitle);
+        $candidate = $this->coreName($candidateTitle);
+
+        // Nothing usable left after normalising — don't guess.
+        if ($master === null || $candidate === null) {
+            return true;
+        }
+
+        if ($master === $candidate) {
+            return true;
+        }
+
+        // Event feeds name the fixture in the title: "DAZN 7 - OH Leuven vs
+        // Standard" is the same channel as plain "DAZN 7". Compare the part
+        // before the first separator too before ruling the pair out.
+        if ($this->eventFeedMatches($masterTitle, $candidateTitle)) {
+            return true;
+        }
+
+        // One name fully containing the other is an abbreviation or a longer
+        // branded form ("NICK JUNIOR" vs "NICKELODEON JUNIOR"), not a mismatch.
+        if (str_contains($master, $candidate) || str_contains($candidate, $master)) {
+            return true;
+        }
+
+        // Two very short names carry too little signal to judge either way —
+        // "ocs" against "tnt" is as unscoreable as it looks. Only abstain when
+        // *both* are short; a short name against a long unrelated one is
+        // genuine evidence of a mismatch, and the abbreviation cases that
+        // matter ("e" inside "eentertainment") were already caught above.
+        if (mb_strlen($master) < self::MIN_COMPARABLE_LENGTH
+            && mb_strlen($candidate) < self::MIN_COMPARABLE_LENGTH) {
+            return true;
+        }
+
+        return $this->similarity($master, $candidate) >= $threshold;
+    }
+
+    /**
+     * Reduce a provider title to a bare channel name: no source prefix, no
+     * quality tokens, no punctuation.
+     *
+     * "VIP: SKY SPORTS F1 ᴴᴰ ʰᵉᵛᶜ" becomes "skysportsf1".
+     */
+    public function coreName(?string $title): ?string
+    {
+        $value = mb_strtolower(trim((string) $title));
+
+        if ($value === '') {
+            return null;
+        }
+
+        // Strip a leading source or country prefix: "VIP:", "DE|", "UK - ".
+        $value = preg_replace('/^[\p{L}\p{N} +._!-]{1,12}[|:]\s*/u', '', $value) ?? $value;
+        $value = preg_replace('/^[\p{L}]{2,6}\s+-\s+/u', '', $value) ?? $value;
+
+        // Drop parenthesised and bracketed asides: "(SAT)", "[EVENTS]".
+        $value = preg_replace('/\((?:[^()]*)\)|\[(?:[^\[\]]*)\]/u', ' ', $value) ?? $value;
+
+        $value = str_replace(self::DECORATIONS, ' ', $value);
+
+        // Remove quality tokens as whole words only, so "HD" goes but the "hd"
+        // inside a real name does not.
+        foreach (self::NOISE_TOKENS as $token) {
+            $value = preg_replace('/(?<![\p{L}\p{N}])'.preg_quote($token, '/').'(?![\p{L}\p{N}])/u', ' ', $value) ?? $value;
+        }
+
+        // Keep letters and digits; everything else was formatting.
+        $value = preg_replace('/[^\p{L}\p{N}]+/u', '', $value) ?? '';
+
+        return $value !== '' ? $value : null;
+    }
+
+    /**
+     * Similarity between two normalised names, 0.0 to 1.0.
+     */
+    public function similarity(string $a, string $b): float
+    {
+        if ($a === $b) {
+            return 1.0;
+        }
+
+        similar_text($a, $b, $percent);
+
+        return round($percent / 100, 4);
+    }
+
+    /**
+     * True when one title is an event-specific feed of the other, e.g.
+     * "BE| DAZN 7 - OH Leuven - Standard Liège" against "BE - DAZN 7".
+     *
+     * The comparison is deliberately asymmetric: the *stripped* form of one
+     * title is matched against the *whole* core name of the other. Comparing
+     * both stripped forms instead would collapse anything sharing a leading
+     * language code — "EN - Detective Chinatown" and "EN - Thirteen Lives"
+     * would both reduce to "en" and be declared the same channel.
+     *
+     * The base also has to be long enough to mean something, so a bare "en"
+     * or "4k" prefix can never carry a match on its own.
+     */
+    private function eventFeedMatches(?string $masterTitle, ?string $candidateTitle): bool
+    {
+        $masterFull = $this->coreName($masterTitle);
+        $candidateFull = $this->coreName($candidateTitle);
+        $masterBase = $this->coreName($this->beforeSeparator($masterTitle));
+        $candidateBase = $this->coreName($this->beforeSeparator($candidateTitle));
+
+        foreach ([[$masterBase, $candidateFull], [$candidateBase, $masterFull]] as [$base, $full]) {
+            if ($base === null || $full === null) {
+                continue;
+            }
+
+            if (mb_strlen($base) < self::MIN_COMPARABLE_LENGTH) {
+                continue;
+            }
+
+            if ($base === $full) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Everything before the first " - ", which is where providers append
+     * fixture or event detail.
+     */
+    private function beforeSeparator(?string $title): ?string
+    {
+        $value = (string) $title;
+        $position = mb_strpos($value, ' - ');
+
+        return $position === false ? $value : mb_substr($value, 0, $position);
+    }
+
+    /**
+     * The title actually shown for a channel, honouring the user's override.
+     */
+    private function effectiveTitle(Channel $channel): ?string
+    {
+        return $channel->title_custom ?: $channel->title;
+    }
+}

--- a/app/Services/ChannelTitleSimilarityService.php
+++ b/app/Services/ChannelTitleSimilarityService.php
@@ -9,7 +9,7 @@ use App\Models\Channel;
  * same channel.
  *
  * This exists because merging trusts its grouping key completely. When a
- * provider hands over a bad stream ID — or the importer mis-parses one — every
+ * provider hands over a bad stream ID - or the importer mis-parses one - every
  * channel sharing that key is treated as the same channel, and unrelated
  * channels end up as each other's failovers. A viewer whose channel drops then
  * gets something entirely different.
@@ -23,29 +23,54 @@ use App\Models\Channel;
 class ChannelTitleSimilarityService
 {
     /**
-     * Quality, format and source tokens that say nothing about channel identity.
+     * Quality and format tokens that say nothing about channel identity.
+     *
+     * Kept deliberately narrow. Anything that can appear inside a real channel
+     * name has to stay out, because stripping it merges channels that are not
+     * the same - with 'ts' and 'vip' in here, "TS TV" and "VIP TV" both reduced
+     * to "tv". 'live' is out for the same reason: "CANAL+ LIVE 14" is the
+     * channel's actual name.
      */
     private const NOISE_TOKENS = [
         'fhd', 'uhd', 'hd', 'sd', 'hq', 'lq', '4k', '8k', '1080p', '720p', '576p', '480p',
-        'hevc', 'h265', 'h264', 'x265', 'x264', 'raw', 'ts', 'm3u8', 'mpegts',
-        'vip', 'backup', 'alt', 'multi', 'plus1', 'live',
+        'hevc', 'h265', 'h264', 'x265', 'x264', 'raw', 'm3u8', 'mpegts',
+        'backup', 'multi',
     ];
 
     /**
      * Superscript and decorative characters providers use as quality markers,
-     * e.g. "UK: BBC ONE ᴴᴰ ◉" or "VIP: SKY SPORTS F1 ⁴ᵏ".
+     * e.g. "UK: BBC ONE HD" written with superscripts, or a trailing bullet.
      */
     private const DECORATIONS = [
-        'ᴴ', 'ᴰ', 'ᴿ', 'ᴬ', 'ᵂ', 'ʰ', 'ᵉ', 'ᵛ', 'ᶜ', 'ᵁ', 'ᴾ', 'ᶠ', 'ˢ',
-        '⁴', 'ᵏ', '³', '⁸', '⁰', '⁵', '¹', '²', '◉', '★', '☆', '⚽', '●',
+        "\u{1D34}", "\u{1D30}", "\u{1D3F}", "\u{1D2C}", "\u{1D42}", "\u{02B0}", "\u{1D49}",
+        "\u{1D5B}", "\u{1D9C}", "\u{1D41}", "\u{1D3E}", "\u{1DA0}", "\u{02E2}",
+        "\u{2074}", "\u{1D4F}", "\u{00B3}", "\u{2078}", "\u{2070}", "\u{2075}",
+        "\u{00B9}", "\u{00B2}", "\u{25C9}", "\u{2605}", "\u{2606}", "\u{26BD}", "\u{25CF}",
     ];
 
     /**
-     * Core names shorter than this can't be compared meaningfully — "E!" reduces
-     * to "e", and a one-character string scores near zero against anything.
-     * Below this length the guard abstains rather than guessing.
+     * Shortest core name that carries enough signal to compare, or to accept as
+     * a containment match. "E!" reduces to "e", which sits inside "espn".
      */
     private const MIN_COMPARABLE_LENGTH = 5;
+
+    /**
+     * Longest input similar_text() is allowed to see. It runs in O(n^3) and a
+     * pair of 3,600-character names takes about 2.7 seconds; a provider feed is
+     * untrusted input and merging walks tens of thousands of channels.
+     *
+     * Truncation alone would let two names differing only past the cap score as
+     * identical, so anything longer than the cap is scored on its head and its
+     * tail, keeping whichever agrees less.
+     */
+    private const MAX_SCORED_LENGTH = 128;
+
+    /**
+     * Shortest trailing segment that makes a title look like an event feed
+     * rather than a sibling channel. "DAZN 7 - OH Leuven - Standard" qualifies;
+     * "SKY SPORTS - NEWS" does not, and Sky Sports News is its own channel.
+     */
+    private const MIN_EVENT_DETAIL_LENGTH = 12;
 
     /**
      * Decide whether a failover candidate plausibly describes the same channel
@@ -78,10 +103,17 @@ class ChannelTitleSimilarityService
             return true;
         }
 
+        // Two titles that both carry a release year and disagree about it are
+        // different films. Settle that before normalising, which drops the year
+        // and would leave "The Thing (1982)" and "The Thing (2011)" identical.
+        if ($this->yearsConflict($masterTitle, $candidateTitle)) {
+            return false;
+        }
+
         $master = $this->coreName($masterTitle);
         $candidate = $this->coreName($candidateTitle);
 
-        // Nothing usable left after normalising — don't guess.
+        // Nothing usable left after normalising - don't guess.
         if ($master === null || $candidate === null) {
             return true;
         }
@@ -91,23 +123,31 @@ class ChannelTitleSimilarityService
         }
 
         // Event feeds name the fixture in the title: "DAZN 7 - OH Leuven vs
-        // Standard" is the same channel as plain "DAZN 7". Compare the part
-        // before the first separator too before ruling the pair out.
+        // Standard" is the same channel as plain "DAZN 7".
         if ($this->eventFeedMatches($masterTitle, $candidateTitle)) {
             return true;
         }
 
-        // One name fully containing the other is an abbreviation or a longer
-        // branded form ("NICK JUNIOR" vs "NICKELODEON JUNIOR"), not a mismatch.
-        if (str_contains($master, $candidate) || str_contains($candidate, $master)) {
+        // An abbreviation sitting inside its expanded form ("NICK JUNIOR" in
+        // "NICKELODEON JUNIOR"). The contained name has to be substantial and
+        // sit at one end, otherwise "e" matches "espn" and every short name
+        // matches half the channel list.
+        if ($this->isAnchoredContainment($master, $candidate)) {
             return true;
         }
 
-        // Two very short names carry too little signal to judge either way —
-        // "ocs" against "tnt" is as unscoreable as it looks. Only abstain when
-        // *both* are short; a short name against a long unrelated one is
-        // genuine evidence of a mismatch, and the abbreviation cases that
-        // matter ("e" inside "eentertainment") were already caught above.
+        // The same idea at word level, which is the only place the difference
+        // between "E!" and "E! ENTERTAINMENT" survives. Squashing to a bare
+        // core loses the boundary, leaving "e" - which then sits inside "espn"
+        // just as happily. Comparing word sequences keeps the first pair and
+        // rejects the second.
+        if ($this->isTokenPrefixOrSuffix($masterTitle, $candidateTitle)) {
+            return true;
+        }
+
+        // Two very short names carry too little signal to judge either way.
+        // Only abstain when both are short; a short name against a long
+        // unrelated one is genuine evidence of a mismatch.
         if (mb_strlen($master) < self::MIN_COMPARABLE_LENGTH
             && mb_strlen($candidate) < self::MIN_COMPARABLE_LENGTH) {
             return true;
@@ -120,7 +160,7 @@ class ChannelTitleSimilarityService
      * Reduce a provider title to a bare channel name: no source prefix, no
      * quality tokens, no punctuation.
      *
-     * "VIP: SKY SPORTS F1 ᴴᴰ ʰᵉᵛᶜ" becomes "skysportsf1".
+     * "VIP: SKY SPORTS F1 HD HEVC" becomes "skysportsf1".
      */
     public function coreName(?string $title): ?string
     {
@@ -130,12 +170,25 @@ class ChannelTitleSimilarityService
             return null;
         }
 
-        // Strip a leading source or country prefix: "VIP:", "DE|", "UK - ".
-        $value = preg_replace('/^[\p{L}\p{N} +._!-]{1,12}[|:]\s*/u', '', $value) ?? $value;
+        // Strip a leading source prefix: "VIP:", "DE|", "SKYGO:", "NEXT |".
+        // Internal spaces are not allowed, so "BBC NEWS: WORLD" keeps its name.
+        // An earlier version matched any 12 characters and reduced both
+        // "BBC NEWS: WORLD" and "CNN NEWS: WORLD" to "world".
+        $value = preg_replace('/^[\p{L}\p{N}+._!-]{1,8}\s?[|:]\s*/u', '', $value) ?? $value;
         $value = preg_replace('/^[\p{L}]{2,6}\s+-\s+/u', '', $value) ?? $value;
 
-        // Drop parenthesised and bracketed asides: "(SAT)", "[EVENTS]".
-        $value = preg_replace('/\((?:[^()]*)\)|\[(?:[^\[\]]*)\]/u', ' ', $value) ?? $value;
+        // Drop bracketed asides only when they are purely format markers such
+        // as "(SAT)" or "(720P)". Anything else is identity - a year, or a
+        // region as in "BBC One (Scotland)" against "BBC One (London)".
+        $value = preg_replace_callback(
+            '/\(([^()]*)\)|\[([^\[\]]*)\]/u',
+            function (array $matches): string {
+                $inner = $matches[1] !== '' ? $matches[1] : ($matches[2] ?? '');
+
+                return $this->isNoiseOnly($inner) ? ' ' : ' '.$inner.' ';
+            },
+            $value
+        ) ?? $value;
 
         $value = str_replace(self::DECORATIONS, ' ', $value);
 
@@ -148,11 +201,35 @@ class ChannelTitleSimilarityService
         // Keep letters and digits; everything else was formatting.
         $value = preg_replace('/[^\p{L}\p{N}]+/u', '', $value) ?? '';
 
-        return $value !== '' ? $value : null;
+        if ($value !== '') {
+            return $value;
+        }
+
+        // Everything was stripped, so the title was nothing but tokens this
+        // class treats as noise - "UK| HD", say. Fall back to the raw
+        // alphanumerics rather than returning null, which would make the caller
+        // abstain on a title it could still have compared.
+        $fallback = preg_replace('/[^\p{L}\p{N}]+/u', '', mb_strtolower(trim((string) $title))) ?? '';
+
+        return $fallback !== '' ? $fallback : null;
     }
 
     /**
      * Similarity between two normalised names, 0.0 to 1.0.
+     *
+     * similar_text() is not commutative - it can return a different figure
+     * depending on argument order, and on real data that flipped the verdict
+     * for a handful of pairs depending on which channel won master selection.
+     * Both directions are scored and the higher figure kept.
+     *
+     * Names longer than the cap are scored on their head *and* their tail, and
+     * the lower of the two scores wins. Scoring only the head would let two
+     * names that differ solely past character 128 come back as identical.
+     *
+     * A length-ratio penalty was tried here and removed: on 12,754 real pairs
+     * it bought 17 extra catches for a tenfold worse false-positive rate,
+     * because legitimate pairs like "NAT GEO WILD" against
+     * "NAT GEOGRAPHIC WILD" differ in length by design.
      */
     public function similarity(string $a, string $b): float
     {
@@ -160,37 +237,166 @@ class ChannelTitleSimilarityService
             return 1.0;
         }
 
-        similar_text($a, $b, $percent);
+        $score = $this->scoreSegment(
+            mb_substr($a, 0, self::MAX_SCORED_LENGTH),
+            mb_substr($b, 0, self::MAX_SCORED_LENGTH),
+        );
 
-        return round($percent / 100, 4);
+        if (mb_strlen($a) > self::MAX_SCORED_LENGTH || mb_strlen($b) > self::MAX_SCORED_LENGTH) {
+            $score = min($score, $this->scoreSegment(
+                mb_substr($a, -self::MAX_SCORED_LENGTH),
+                mb_substr($b, -self::MAX_SCORED_LENGTH),
+            ));
+        }
+
+        return round($score, 4);
+    }
+
+    /**
+     * Score one bounded pair of segments in both directions, since
+     * similar_text() is not commutative.
+     */
+    private function scoreSegment(string $a, string $b): float
+    {
+        similar_text($a, $b, $forward);
+        similar_text($b, $a, $reverse);
+
+        return max($forward, $reverse) / 100;
+    }
+
+    /**
+     * The normalised words of a title, boundaries intact.
+     *
+     * @return array<int, string>
+     */
+    public function coreTokens(?string $title): array
+    {
+        $core = $this->coreName($title);
+
+        if ($core === null) {
+            return [];
+        }
+
+        // Re-run the normalisation, but split on the separators instead of
+        // deleting them, so the word boundaries survive.
+        $value = mb_strtolower(trim((string) $title));
+        $value = preg_replace('/^[\p{L}\p{N}+._!-]{1,8}\s?[|:]\s*/u', ' ', $value) ?? $value;
+        $value = preg_replace('/^[\p{L}]{2,6}\s+-\s+/u', ' ', $value) ?? $value;
+        $value = str_replace(self::DECORATIONS, ' ', $value);
+
+        $words = preg_split('/[^\p{L}\p{N}]+/u', $value, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+
+        return array_values(array_filter(
+            $words,
+            fn (string $word) => ! in_array($word, self::NOISE_TOKENS, true)
+                && preg_match('/^\d{3,4}[ip]$/', $word) !== 1
+        ));
+    }
+
+    /**
+     * True when one title's words are a leading or trailing run of the other's.
+     *
+     * ["e"] against ["e", "entertainment"] matches; ["e"] against ["espn"] does
+     * not, because a whole word has to line up rather than a few characters.
+     */
+    private function isTokenPrefixOrSuffix(?string $masterTitle, ?string $candidateTitle): bool
+    {
+        $a = $this->coreTokens($masterTitle);
+        $b = $this->coreTokens($candidateTitle);
+
+        if ($a === [] || $b === []) {
+            return false;
+        }
+
+        [$short, $long] = count($a) <= count($b) ? [$a, $b] : [$b, $a];
+
+        if (count($short) === count($long)) {
+            return false;
+        }
+
+        return array_slice($long, 0, count($short)) === $short
+            || array_slice($long, -count($short)) === $short;
+    }
+
+    /**
+     * True when one core name sits at the start or end of the other and is long
+     * enough to mean something on its own.
+     *
+     * Anchoring matters: an unanchored check accepts any short name found
+     * anywhere inside a longer one, which is how "e" ends up matching "espn".
+     */
+    private function isAnchoredContainment(string $a, string $b): bool
+    {
+        [$short, $long] = mb_strlen($a) <= mb_strlen($b) ? [$a, $b] : [$b, $a];
+
+        if (mb_strlen($short) < self::MIN_COMPARABLE_LENGTH) {
+            return false;
+        }
+
+        return str_starts_with($long, $short) || str_ends_with($long, $short);
+    }
+
+    /**
+     * True when both titles carry a four-digit year and the years differ.
+     *
+     * Years only show up on VOD titles, so a disagreement is decisive: two
+     * films with the same name and different years are different films.
+     */
+    private function yearsConflict(?string $masterTitle, ?string $candidateTitle): bool
+    {
+        $master = $this->releaseYear($masterTitle);
+        $candidate = $this->releaseYear($candidateTitle);
+
+        return $master !== null && $candidate !== null && $master !== $candidate;
+    }
+
+    /**
+     * Pull a plausible release year out of a title, or null when there isn't one.
+     */
+    private function releaseYear(?string $title): ?string
+    {
+        if (preg_match('/\((19|20)(\d{2})\)/', (string) $title, $matches) === 1) {
+            return $matches[1].$matches[2];
+        }
+
+        return null;
     }
 
     /**
      * True when one title is an event-specific feed of the other, e.g.
-     * "BE| DAZN 7 - OH Leuven - Standard Liège" against "BE - DAZN 7".
+     * "BE| DAZN 7 - OH Leuven - Standard" against "BE - DAZN 7".
      *
-     * The comparison is deliberately asymmetric: the *stripped* form of one
-     * title is matched against the *whole* core name of the other. Comparing
-     * both stripped forms instead would collapse anything sharing a leading
-     * language code — "EN - Detective Chinatown" and "EN - Thirteen Lives"
-     * would both reduce to "en" and be declared the same channel.
+     * The comparison is asymmetric on purpose: the stripped form of one title
+     * is matched against the whole core name of the other. Comparing both
+     * stripped forms would collapse anything sharing a leading language code -
+     * "EN - Detective Chinatown" and "EN - Thirteen Lives" would both reduce to
+     * "en" and be declared the same channel.
      *
-     * The base also has to be long enough to mean something, so a bare "en"
-     * or "4k" prefix can never carry a match on its own.
+     * The trailing segment also has to actually look like event detail.
+     * Without that, any "X - Y" title matches a plain "X", and
+     * "SKY SPORTS - NEWS" becomes a failover for "SKY SPORTS" despite being a
+     * channel in its own right.
      */
     private function eventFeedMatches(?string $masterTitle, ?string $candidateTitle): bool
     {
         $masterFull = $this->coreName($masterTitle);
         $candidateFull = $this->coreName($candidateTitle);
-        $masterBase = $this->coreName($this->beforeSeparator($masterTitle));
-        $candidateBase = $this->coreName($this->beforeSeparator($candidateTitle));
 
-        foreach ([[$masterBase, $candidateFull], [$candidateBase, $masterFull]] as [$base, $full]) {
-            if ($base === null || $full === null) {
+        $pairs = [
+            [$this->coreName($this->beforeSeparator($masterTitle)), $candidateFull, $this->afterSeparator($masterTitle)],
+            [$this->coreName($this->beforeSeparator($candidateTitle)), $masterFull, $this->afterSeparator($candidateTitle)],
+        ];
+
+        foreach ($pairs as [$base, $full, $detail]) {
+            if ($base === null || $full === null || $detail === null) {
                 continue;
             }
 
             if (mb_strlen($base) < self::MIN_COMPARABLE_LENGTH) {
+                continue;
+            }
+
+            if (! $this->looksLikeEventDetail($detail)) {
                 continue;
             }
 
@@ -200,6 +406,38 @@ class ChannelTitleSimilarityService
         }
 
         return false;
+    }
+
+    /**
+     * A fixture reads like "OH Leuven - Standard Liege" - several words, and
+     * long. A sibling channel's suffix reads like "NEWS".
+     */
+    private function looksLikeEventDetail(string $detail): bool
+    {
+        $detail = trim($detail);
+
+        return mb_strlen($detail) >= self::MIN_EVENT_DETAIL_LENGTH && str_contains($detail, ' ');
+    }
+
+    /**
+     * True when bracketed text is nothing but format markers, e.g. "(SAT)" or
+     * "(720P)", as opposed to "(1982)" or "(Scotland)", which are identity.
+     */
+    private function isNoiseOnly(string $inner): bool
+    {
+        $words = preg_split('/[^\p{L}\p{N}]+/u', mb_strtolower(trim($inner)), -1, PREG_SPLIT_NO_EMPTY) ?: [];
+
+        if ($words === []) {
+            return true;
+        }
+
+        foreach ($words as $word) {
+            if (! in_array($word, self::NOISE_TOKENS, true) && preg_match('/^\d{3,4}[ip]$/', $word) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -215,10 +453,26 @@ class ChannelTitleSimilarityService
     }
 
     /**
-     * The title actually shown for a channel, honouring the user's override.
+     * Everything after the first " - ", or null when there is no separator.
+     */
+    private function afterSeparator(?string $title): ?string
+    {
+        $value = (string) $title;
+        $position = mb_strpos($value, ' - ');
+
+        return $position === false ? null : mb_substr($value, $position + 3);
+    }
+
+    /**
+     * The title actually shown for a channel, honouring the user's override and
+     * falling back to the name fields, which is what merging itself falls back
+     * to when a channel carries no title.
      */
     private function effectiveTitle(Channel $channel): ?string
     {
-        return $channel->title_custom ?: $channel->title;
+        return $channel->title_custom
+            ?: $channel->title
+            ?: $channel->name_custom
+            ?: $channel->name;
     }
 }

--- a/tests/Unit/ChannelTitleSimilarityServiceTest.php
+++ b/tests/Unit/ChannelTitleSimilarityServiceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Services\ChannelTitleSimilarityService;
+
+beforeEach(function () {
+    $this->service = new ChannelTitleSimilarityService;
+});
+
+it('strips source prefixes and quality decorations down to the channel name', function (string $title, string $expected) {
+    expect($this->service->coreName($title))->toBe($expected);
+})->with([
+    ['DE| SYFY HEVC', 'syfy'],
+    ['JOYN| SYFY FHD ᴿᴬᵂ', 'syfy'],
+    ['VIP: SKY SPORTS F1 ᴴᴰ ʰᵉᵛᶜ', 'skysportsf1'],
+    ['UK: BBC 3 / CBBC HD ◉', 'bbc3cbbc'],
+    ['FR - W9 HEVC', 'w9'],
+    ['DE: DISCOVERY HD (720P)', 'discovery'],
+    ['IT| CIELO UHD', 'cielo'],
+]);
+
+it('returns null when a title has no usable content', function (?string $title) {
+    expect($this->service->coreName($title))->toBeNull();
+})->with([[null], [''], ['   '], ['HD'], ['4K']]);
+
+it('treats a zero threshold as the guard being switched off', function () {
+    expect($this->service->titlesMatch('UK: BBC 3', 'UK: FOOD NETWORK', 0.0))->toBeTrue();
+});
+
+it('rejects titles that describe genuinely different channels', function (string $master, string $candidate) {
+    expect($this->service->titlesMatch($master, $candidate, 0.4))->toBeFalse();
+})->with([
+    // The case this guard exists for: a mis-parsed stream id grouped these.
+    ['UK: BBC 3 / CBBC HD ◉', 'UK: FOOD NETWORK +1 ◉'],
+    ['UK: BBC 3 / CBBC HD ◉', 'UK: ITV LONDON 4K ◉'],
+    ['FR| TLC HD', 'FR - DISCOVERY SCIENCE'],
+    ['ES| 13 TV SD', 'ES| CALLE 13 HEVC'],
+    ['UK| TRUE CRIME', 'UK - CBS DRAMA'],
+    // Two unrelated films sharing only a language prefix.
+    ['EN - Pitch Perfect 3  (2017)', 'ES - Tenéis que venir a verla (2023)'],
+    ['EN - Detective Chinatown  (2015)', '4K-EN - Thirteen Lives  (2022)'],
+]);
+
+it('accepts the same channel across sources and quality variants', function (string $master, string $candidate) {
+    expect($this->service->titlesMatch($master, $candidate, 0.4))->toBeTrue();
+})->with([
+    ['DE| SYFY HEVC', 'DE| SYFY FHD'],
+    ['FR| W9 4K', 'FR - W9 HEVC'],
+    ['FR| LCI HD ᴿᴬᵂ', 'FR| LCI FHD'],
+    ['IT| CIELO UHD', 'IT: CIELO HEVC'],
+    ['VIP: SKY SPORTS F1 ᴴᴰ', 'SKYGO: SKY SPORT F1 4K'],
+    ['FR| NAT GEO WILD HD', 'BE| NAT GEOGRAPHIC WILD HD'],
+    ['UK| NICKELODEON FHD', 'NOW: NICKELODEON ᴴᴰ'],
+]);
+
+it('accepts an event feed matched against its base channel', function () {
+    // Comparing the stripped form of both titles would reduce each to its
+    // language prefix; the base has to be matched against the whole name.
+    expect($this->service->titlesMatch('BE| DAZN 7 - OH Leuven - Standard', 'BE - DAZN 7', 0.4))->toBeTrue();
+    expect($this->service->titlesMatch('BE: DAZN 11', 'BE| DAZN 11 - Union SG - RSC Anderlecht', 0.4))->toBeTrue();
+});
+
+it('does not let a shared language prefix carry a match on its own', function () {
+    // Both titles reduce to "en" before the separator. If the base were
+    // compared against the other base rather than the other full name, these
+    // two unrelated films would be declared the same channel.
+    expect($this->service->titlesMatch('EN - Nine Days  (2021)', 'EN - Hungry Dog Blues  (2022)', 0.4))->toBeFalse();
+});
+
+it('accepts an abbreviation contained in its expanded form', function () {
+    expect($this->service->titlesMatch('FR| E! FHD', 'FR - E! ENTERTAINMENT FHD', 0.4))->toBeTrue();
+    expect($this->service->titlesMatch('UK| NICK JR FHD', 'UK| NICKELODEON JUNIOR HD', 0.4))->toBeTrue();
+});
+
+it('abstains only when both names are too short to compare', function () {
+    // Both short and unrelated - no signal either way, so keep the pair.
+    expect($this->service->titlesMatch('FR| OCS HD', 'RO - TNT', 0.4))->toBeTrue();
+
+    // One short, one long, nothing in common - that is real evidence.
+    expect($this->service->titlesMatch('UK: BBC 3 / CBBC HD ◉', 'UK: RT UK HD ◉', 0.4))->toBeFalse();
+});
+
+it('scores identical names as a perfect match', function () {
+    expect($this->service->similarity('syfy', 'syfy'))->toBe(1.0);
+});

--- a/tests/Unit/ChannelTitleSimilarityServiceTest.php
+++ b/tests/Unit/ChannelTitleSimilarityServiceTest.php
@@ -20,7 +20,102 @@ it('strips source prefixes and quality decorations down to the channel name', fu
 
 it('returns null when a title has no usable content', function (?string $title) {
     expect($this->service->coreName($title))->toBeNull();
-})->with([[null], [''], ['   '], ['HD'], ['4K']]);
+})->with([[null], [''], ['   '], ['|'], ['---']]);
+
+it('falls back to the raw text when a title is nothing but noise tokens', function (string $title, string $expected) {
+    // Returning null here would make the caller abstain on a title it could
+    // still have compared against another.
+    expect($this->service->coreName($title))->toBe($expected);
+})->with([
+    ['HD', 'hd'],
+    ['4K', '4k'],
+    ['UK| HD', 'ukhd'],
+]);
+
+it('keeps tokens that are part of a real channel name', function (string $title, string $expected) {
+    // 'ts', 'vip' and 'live' are deliberately absent from the noise list. With
+    // them in, "TS TV" and "VIP TV" both reduced to "tv" and matched each other.
+    expect($this->service->coreName($title))->toBe($expected);
+})->with([
+    ['UK| TS TV', 'tstv'],
+    ['ES| VIP TV', 'viptv'],
+    ['FR: CANAL+ LIVE 14', 'canallive14'],
+]);
+
+it('no longer collapses two different channels to an identical core', function () {
+    // With 'ts' and 'vip' treated as noise these both reduced to "tv" and
+    // matched by exact equality, which no threshold could override. They score
+    // 0.44 against each other now, so the threshold decides - which is the
+    // point.
+    expect($this->service->coreName('UK| TS TV'))->not->toBe($this->service->coreName('ES| VIP TV'));
+});
+
+it('refuses two films that share a name but not a year', function () {
+    // Normalisation drops the year, so this has to be settled before it runs or
+    // both titles reduce to "thething" and match exactly.
+    expect($this->service->titlesMatch('EN - The Thing (1982)', 'EN - The Thing (2011)', 0.4))->toBeFalse();
+});
+
+it('keeps a region in brackets instead of deleting it', function () {
+    // Stripping all bracketed text reduced both of these to "bbcone" and made
+    // them an exact match at every threshold. They now differ, and how the pair
+    // is treated is left to the threshold - at 0.4 they still score ~0.6, which
+    // is the documented limit for same-brand regional feeds.
+    expect($this->service->coreName('UK: BBC One (Scotland)'))->toBe('bbconescotland');
+    expect($this->service->coreName('UK: BBC One (London)'))->toBe('bbconelondon');
+    expect($this->service->titlesMatch('UK: BBC One (Scotland)', 'UK: BBC One (London)', 0.8))->toBeFalse();
+});
+
+it('still strips brackets holding nothing but a format marker', function () {
+    expect($this->service->coreName('DE: DISCOVERY HD (720P)'))->toBe('discovery');
+});
+
+it('does not mistake a multi-word prefix for source metadata', function () {
+    // An earlier pattern matched any 12 characters before the delimiter and
+    // reduced both of these to "world".
+    expect($this->service->coreName('BBC NEWS: WORLD'))->toBe('bbcnewsworld');
+    expect($this->service->coreName('CNN NEWS: WORLD'))->toBe('cnnnewsworld');
+    // Distinct cores rather than the exact match the old pattern produced.
+    // They still share 9 of 12 characters and score ~0.83, so no threshold in
+    // normal use separates them - a limitation, but a far cry from collapsing
+    // both to "world".
+    expect($this->service->coreName('BBC NEWS: WORLD'))
+        ->not->toBe($this->service->coreName('CNN NEWS: WORLD'));
+});
+
+it('matches an abbreviation on whole words, not stray characters', function () {
+    // ["e"] is a leading word of ["e", "entertainment"], but not of ["espn"].
+    expect($this->service->coreTokens('FR| E! FHD'))->toBe(['e']);
+    expect($this->service->coreTokens('FR - E! ENTERTAINMENT FHD'))->toBe(['e', 'entertainment']);
+    expect($this->service->coreTokens('UK| ESPN HD'))->toBe(['espn']);
+});
+
+it('does not treat a sibling channel suffix as event detail', function () {
+    // "NEWS" is too short to be a fixture, so the event-feed shortcut must not
+    // fire for it the way it does for "OH Leuven - Standard".
+    $method = new ReflectionMethod($this->service, 'eventFeedMatches');
+
+    expect($method->invoke($this->service, 'UK| SKY SPORTS - NEWS', 'UK| SKY SPORTS'))->toBeFalse();
+    expect($method->invoke($this->service, 'BE| DAZN 7 - OH Leuven - Standard', 'BE - DAZN 7'))->toBeTrue();
+});
+
+it('does not let truncation manufacture a perfect score', function () {
+    // Two names differing only past the scoring cap must not come back
+    // identical; the tail is scored as well as the head.
+    $prefix = str_repeat('a', 128);
+
+    expect($this->service->similarity($prefix.'x', $prefix.'y'))->toBeLessThan(1.0);
+});
+
+it('scores the same regardless of argument order', function () {
+    // similar_text() is not commutative, so the raw call can return different
+    // figures for (a,b) and (b,a) and flip the verdict.
+    $a = 'UK| BUENA VISTA SOCIAL CLUB';
+    $b = 'ES| SUPERACION LA HISTORIA';
+
+    expect($this->service->titlesMatch($a, $b, 0.4))
+        ->toBe($this->service->titlesMatch($b, $a, 0.4));
+});
 
 it('treats a zero threshold as the guard being switched off', function () {
     expect($this->service->titlesMatch('UK: BBC 3', 'UK: FOOD NETWORK', 0.0))->toBeTrue();

--- a/tests/Unit/MergeChannelsTest.php
+++ b/tests/Unit/MergeChannelsTest.php
@@ -492,3 +492,126 @@ it('rotates a scrubber dead master to a live failover and restores it when live 
         'channel_failover_id' => $secondaryFailover->id,
     ]);
 });
+
+it('keeps merging unrelated titles when the similarity guard is off', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->createQuietly();
+
+    // Same stream_id, wildly different channels. This is the pre-existing
+    // behaviour and must not change unless the guard is explicitly turned on.
+    foreach (['UK: BBC 3 / CBBC HD', 'UK: FOOD NETWORK +1'] as $index => $title) {
+        Channel::factory()->create([
+            'stream_id' => 'TS',
+            'title' => $title,
+            'url' => "http://provider.test/stream/{$index}.ts",
+            'user_id' => $user->id,
+            'playlist_id' => $playlist->id,
+            'group_id' => null,
+            'enabled' => true,
+        ]);
+    }
+
+    $playlists = collect([['playlist_failover_id' => $playlist->id]]);
+
+    runMergeChannels($user, $playlists, $playlist->id);
+
+    $this->assertDatabaseCount('channel_failovers', 1);
+});
+
+it('does not create a failover when the titles describe different channels', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->createQuietly();
+
+    // A mis-parsed stream id ("TS" is the container extension, not an id) is
+    // enough to group unrelated channels. The guard should refuse the pairing.
+    foreach (['UK: BBC 3 / CBBC HD', 'UK: FOOD NETWORK +1'] as $index => $title) {
+        Channel::factory()->create([
+            'stream_id' => 'TS',
+            'title' => $title,
+            'url' => "http://provider.test/stream/{$index}.ts",
+            'user_id' => $user->id,
+            'playlist_id' => $playlist->id,
+            'group_id' => null,
+            'enabled' => true,
+        ]);
+    }
+
+    $playlists = collect([['playlist_failover_id' => $playlist->id]]);
+
+    runMergeChannels($user, $playlists, $playlist->id, minTitleSimilarity: 0.4);
+
+    $this->assertDatabaseCount('channel_failovers', 0);
+});
+
+it('still merges the same channel across quality variants when the guard is on', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->createQuietly();
+
+    // Source prefixes and quality suffixes differ, the channel does not.
+    // Comparing the raw titles would score these as unrelated.
+    foreach (['DE| SYFY HEVC', 'JOYN| SYFY FHD ᴿᴬᵂ'] as $index => $title) {
+        Channel::factory()->create([
+            'stream_id' => 'syfy.de',
+            'title' => $title,
+            'url' => "http://provider.test/stream/syfy-{$index}.ts",
+            'user_id' => $user->id,
+            'playlist_id' => $playlist->id,
+            'group_id' => null,
+            'enabled' => true,
+        ]);
+    }
+
+    $playlists = collect([['playlist_failover_id' => $playlist->id]]);
+
+    runMergeChannels($user, $playlists, $playlist->id, minTitleSimilarity: 0.4);
+
+    $this->assertDatabaseCount('channel_failovers', 1);
+});
+
+it('still merges an event feed against its base channel when the guard is on', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->createQuietly();
+
+    // Providers append the fixture to the title of the channel carrying it.
+    foreach (['BE| DAZN 7 - OH Leuven - Standard', 'BE - DAZN 7'] as $index => $title) {
+        Channel::factory()->create([
+            'stream_id' => 'dazn7.be',
+            'title' => $title,
+            'url' => "http://provider.test/stream/dazn-{$index}.ts",
+            'user_id' => $user->id,
+            'playlist_id' => $playlist->id,
+            'group_id' => null,
+            'enabled' => true,
+        ]);
+    }
+
+    $playlists = collect([['playlist_failover_id' => $playlist->id]]);
+
+    runMergeChannels($user, $playlists, $playlist->id, minTitleSimilarity: 0.4);
+
+    $this->assertDatabaseCount('channel_failovers', 1);
+});
+
+it('still merges an abbreviated title against its expanded form when the guard is on', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->createQuietly();
+
+    // "E!" reduces to a single character; scoring it would call these unrelated.
+    foreach (['FR| E! FHD', 'FR - E! ENTERTAINMENT HD'] as $index => $title) {
+        Channel::factory()->create([
+            'stream_id' => 'e.fr',
+            'title' => $title,
+            'url' => "http://provider.test/stream/e-{$index}.ts",
+            'user_id' => $user->id,
+            'playlist_id' => $playlist->id,
+            'group_id' => null,
+            'enabled' => true,
+        ]);
+    }
+
+    $playlists = collect([['playlist_failover_id' => $playlist->id]]);
+
+    runMergeChannels($user, $playlists, $playlist->id, minTitleSimilarity: 0.4);
+
+    $this->assertDatabaseCount('channel_failovers', 1);
+});


### PR DESCRIPTION
**Draft on purpose.** There's a question at the bottom I'd rather have answered before you spend time reviewing an implementation. The bug is real either way; the fix is a proposal.

## The bug

`MergeChannels` groups channels by `stream_id` and writes a `ChannelFailover` for every other member of the group. Apart from the URL-duplicate check from #1382, nothing checks what those channels are — the merge key is taken entirely on faith.

That's fine until the key isn't unique, and on an Xtream playlist `stream_id` holds the provider's tvg-id — `ProcessM3uImportChunk.php:122` documents it as *"provider stream ID or tvg-id ... for Xtream API this could be `epg_channel_id`"*.

On my install the provider returns the literal string `TS` in `epg_channel_id` for 82 channels:

```
name           = UK: BBC 3 / CBBC HD ◉
stream_id      = 162100
epg_channel_id = TS          <-- provider's value, stored as channels.stream_id
```

The editor stores that faithfully and keeps the real ID in `source_id`. All 82 therefore share one merge key and grouped as a single channel. `UK: BBC 3 / CBBC HD` came out with **81 failovers**, among them Food Network +1, HGTV +1, ITV London 4K, Daystar, Film4 and Horror Xtra. When BBC 3 drops, the viewer gets Food Network.

VOD is worse, because nothing about it is defensible: *Pitch Perfect 3* failing over to *Tenéis que venir a verla*, *Brimstone* to *Doctor Strange*.

Providers cause the same shape of problem on their own — nine Sky Sports **Darts** channels here ship with `tvg-id="SkySportsF1.uk"`, so Darts became a backup for F1.

Across 12,754 failovers on my install, 534 paired channels that have nothing to do with each other.

**Correction:** an earlier version of this description blamed the importer for parsing the URL. That was wrong — I inferred it from these URLs ending in `.ts` and never checked the payload or the import path. There is no URL parsing; the value comes straight from the provider. Details and the raw payload are in the comments below.

The wider pattern is that `stream_id` is not unique on any of my playlists while `source_id` is:

| Playlist | Channels | distinct `source_id` | distinct `stream_id` |
|---|---|---|---|
| A | 45,416 | 45,416 | 37,158 |
| B | 12,371 | 12,371 | 1,233 |
| C | 31,212 | 31,212 | 26,056 |

Every collision group holds fully distinct `source_id`s. Grouping on the tvg-id is deliberate — it's the cross-provider identity, and `source_id` is provider-local — but it means the merge key is a field providers fill with whatever they like.

## What this proposes

A `minTitleSimilarity` option on `MergeChannels`. When set, a candidate has to agree with its master on title as well as on merge key.

Being straight about what it is: **a heuristic filter, not a compatibility guarantee.** It can flag a pairing as implausible. It cannot establish that two channels *are* the same. It defaults to `0.0` (off), so nothing changes unless someone opts in, and it abstains whenever it can't judge confidently.

Comparing raw titles doesn't work — provider titles are mostly not the channel name, and a source prefix plus quality decorations dominate any comparison. `DE| SYFY HEVC` against `DE| SYFY FHD` is the same channel and scores 0.47. So titles reduce to a bare core name first, and only the cores get compared.

## Three worked examples at threshold 0.40

Real pairs from a live install, not constructed:

**Caught** (487 of 534):
```
UK| TRUE CRIME HD    vs  UK: CBS REALITY            cores truecrime / cbsreality     sim 0.32
DE| RTL HEVC         vs  DE| BILD+ EVENT FAME ...   cores rtl / bildeventfame...     sim 0.08
```

**Missed** (47 — kept, shouldn't have been):
```
IT| REALTIME UHD     vs  IT: SKY RETE 7             cores realtime / skyrete7        sim 0.50
IT| SKY DAZN 1 UHD   vs  IT - DAZN CHANNEL HEVC     cores skydazn1 / daznchannel     sim 0.42
```

**Wrongly rejected** (21 — legitimate pairs refused):
```
DE: LEAGUES FOOTBALL PPV 1 - NO EVENT...  vs  ENDED | FV RAVENSBURG VS SSV REUTLINGEN...  sim 0.32
```
That one is a PPV channel against the fixture it's currently carrying. The titles share almost nothing and no title comparison recovers it.

## Full numbers

| Threshold | Correctly kept | False positives | Bad pairs caught | Missed |
|---|---|---|---|---|
| 0.30 | 12,205 | 15 (0.12%) | 448 | 86 |
| **0.40** | **12,199** | **21 (0.17%)** | **487** | **47** |
| 0.50 | 12,113 | 107 (0.88%) | 498 | 36 |
| 0.55 | 11,951 | 269 (2.20%) | 514 | 20 |

0.40 is the knee. Verified across all 12,754 pairs that `0.0` changes nothing.

**The number that actually matters for a decision** isn't the 0.17% false-positive rate against everything kept — it's the collateral rate among what gets blocked. At 0.40 the guard blocks 508 pairs, and **21 of those (4.1%) are legitimate**. So roughly one in twenty-four blocks is wrong. That's the tradeoff, stated the honest way.

## What it can't do

Same-brand siblings defeat it, and I don't think any scoring approach fixes them. Sky Sports Darts against Sky Sports F1 scores 0.53. `BBC One (Scotland)` against `BBC One (London)` about 0.6. `BBC NEWS: WORLD` against `CNN NEWS: WORLD` about 0.83, since they share nine of twelve characters. Real overlapping text, different channels.

Two names both under five characters are abstained on rather than guessed at.

Nothing here repairs a bad `stream_id`, and existing bad failovers are untouched — this only affects merges run afterwards.

## Review history

The first version had nine defects, found by an adversarial review and all reproduced before being fixed. Two were the kind that make a feature actively harmful: the guard was skipped entirely when the master had no URL, and bracketed text was stripped so `The Thing (1982)` and `The Thing (2011)` both normalised to `thething` — the guard *accepted* one film as the other's failover. Each has a regression test now, and the hardened version beats the first on both precision and recall.

One approach tried and dropped: scaling the score by the ratio of the two name lengths. Principled-looking, fixed two edge cases, and cost a tenfold worse false-positive rate on the same dataset, because legitimate pairs like `NAT GEO WILD` and `NAT GEOGRAPHIC WILD` differ in length by design.

## Running it

```bash
vendor/bin/pest tests/Unit/MergeChannelsTest.php tests/Unit/ChannelTitleSimilarityServiceTest.php
vendor/bin/pint --test app/Services/ChannelTitleSimilarityService.php app/Jobs/MergeChannels.php
```
61 tests, 96 assertions, Pint clean locally.

**CI note:** Security Scan fails on four `league/commonmark` advisories published 2026-09-01. This branch doesn't touch `composer.json` or `composer.lock` — both are byte-identical to master and the branch is 0 commits behind. Tests and Docker Build are gated behind Security Scan, so **the test job has never run on this PR**. Everything above is from local runs.

## The question

Do you actually want this behaviour upstream?

I built it because it bit me, but it's unsolicited, it's domain-specific, and a heuristic with known blind spots is a maintenance burden someone else ends up carrying. Three ways this could go, and I'm happy with any of them:

1. You want it roughly as-is, and I take review feedback.
2. You'd rather have a simpler compatibility invariant than a similarity score — tell me the rule and I'll implement that instead.
3. It's too specific for upstream and this closes. The `'TS'` importer parse is still worth a look on its own, and I'll open that as a plain issue with a fixture.

