### PR TITLE
feat(xtream): pause provider calls after an HTTP 429 instead of retrying

### DIFF
--- a/app/Services/XtreamService.php
+++ b/app/Services/XtreamService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\Playlist;
 use Exception;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -105,11 +106,19 @@ class XtreamService
         $user_agent = $this->playlist?->user_agent ?? 'VLC/3.0.21 LibVLC/3.0.21';
         $verify = ! ($this->playlist?->disable_ssl_verification ?? false);
 
+        // A provider that answered 429 is left alone until the cooldown elapses:
+        // retrying only keeps the account rate limited (and every client with it).
+        $this->throwIfRateLimited($url);
+
         // Try the primary URL first
         $result = $this->attemptCall($url, $timeout, $user_agent, $verify);
         if ($result !== null) {
             return $result;
         }
+
+        // The limit is per account, and fallback URLs share the account — do not
+        // knock on the next door with the same credentials.
+        $this->throwIfRateLimited($url);
 
         // Primary failed — try fallback URLs
         if (! empty($this->fallbackUrls)) {
@@ -180,6 +189,11 @@ class XtreamService
                 if ($response->ok()) {
                     return $response->json();
                 }
+                if ($response->status() === 429) {
+                    $this->markRateLimited($url);
+
+                    return null;
+                }
             } catch (Exception $e) {
                 // Connection error — continue retrying
             }
@@ -191,6 +205,44 @@ class XtreamService
         } while ($attempts < $this->retryLimit);
 
         return null;
+    }
+
+    /**
+     * Cache key of the rate-limit circuit for the host of the given URL.
+     */
+    protected function rateLimitKey(string $url): string
+    {
+        return 'xtream:rate_limited:'.strtolower((string) (parse_url($url, PHP_URL_HOST) ?: $url));
+    }
+
+    /**
+     * Open the circuit for this host: no further calls until the cooldown elapses.
+     */
+    protected function markRateLimited(string $url): void
+    {
+        $seconds = max(1, (int) config('xtream.rate_limit_cooldown', 900));
+        Cache::put($this->rateLimitKey($url), now()->addSeconds($seconds)->timestamp, $seconds);
+
+        Log::warning('Xtream provider answered 429, pausing calls', [
+            'host' => parse_url($url, PHP_URL_HOST),
+            'cooldown_seconds' => $seconds,
+            'playlist_id' => $this->playlist?->id,
+        ]);
+    }
+
+    /**
+     * @throws Exception when the host is currently rate limited.
+     */
+    protected function throwIfRateLimited(string $url): void
+    {
+        $until = Cache::get($this->rateLimitKey($url));
+        if ($until && (int) $until > now()->timestamp) {
+            throw new Exception(sprintf(
+                'Xtream provider %s is rate limited (HTTP 429), calls paused until %s',
+                parse_url($url, PHP_URL_HOST),
+                date('c', (int) $until)
+            ));
+        }
     }
 
     protected function makeUrl(string $action, array $extra = []): string

--- a/config/xtream.php
+++ b/config/xtream.php
@@ -27,4 +27,8 @@ return [
 
     // base strm output path (inside storage/app/private/[output_path]/[playlist_id])
     'output_path' => env('XTREAM_STRM_FOLDER', 'strm'),
+
+    // Seconds to pause all calls to a provider host after it answered HTTP 429.
+    // Retrying feeds the limit; leaving the account alone is what makes it drop.
+    'rate_limit_cooldown' => (int) env('XTREAM_RATE_LIMIT_COOLDOWN', 900),
 ];

--- a/tests/Feature/XtreamRateLimitCircuitBreakerTest.php
+++ b/tests/Feature/XtreamRateLimitCircuitBreakerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use App\Models\Playlist;
+use App\Models\User;
+use App\Services\XtreamService;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+
+beforeEach(function () {
+    Queue::fake();
+    Cache::flush();
+    $this->playlist = Playlist::factory()->for(User::factory())->create([
+        'xtream' => true,
+        'xtream_config' => [
+            'url' => 'http://primary.example.com:8080',
+            'username' => 'testuser',
+            'password' => 'testpass',
+        ],
+        'xtream_fallback_urls' => null,
+    ]);
+});
+
+it('stops retrying as soon as the provider answers 429', function () {
+    Http::fake(['*' => Http::response('Too Many Requests', 429)]);
+
+    $service = XtreamService::make(playlist: $this->playlist, retryLimit: 3);
+
+    expect(fn () => $service->userInfo())->toThrow(Exception::class, 'rate limit');
+    Http::assertSentCount(1);
+});
+
+it('refuses further calls without touching the network while rate limited', function () {
+    Http::fake(['*' => Http::response('Too Many Requests', 429)]);
+
+    $service = XtreamService::make(playlist: $this->playlist, retryLimit: 3);
+    expect(fn () => $service->userInfo())->toThrow(Exception::class);
+
+    // Second call, same host: the circuit is open, nothing goes out.
+    expect(fn () => $service->getSeriesInfo('42'))->toThrow(Exception::class, 'rate limit');
+    Http::assertSentCount(1);
+
+    // A fresh instance shares the state (it lives in the cache, not the object).
+    $other = XtreamService::make(playlist: $this->playlist, retryLimit: 3);
+    expect(fn () => $other->userInfo())->toThrow(Exception::class, 'rate limit');
+    Http::assertSentCount(1);
+});
+
+it('does not try fallback URLs on 429 — the limit is per account, not per host', function () {
+    Http::fake([
+        'primary.example.com:8080/*' => Http::response('Too Many Requests', 429),
+        'fallback1.example.com:8080/*' => Http::response(['user_info' => ['status' => 'Active']], 200),
+    ]);
+    $this->playlist->update(['xtream_fallback_urls' => ['http://fallback1.example.com:8080']]);
+
+    $service = XtreamService::make(playlist: $this->playlist, retryLimit: 1);
+
+    expect(fn () => $service->userInfo())->toThrow(Exception::class, 'rate limit');
+    Http::assertSentCount(1);
+    Http::assertNotSent(fn ($request) => str_contains($request->url(), 'fallback1'));
+});
+
+it('lets calls through again once the cooldown has elapsed', function () {
+    Http::fake([
+        '*' => Http::sequence()
+            ->push('Too Many Requests', 429)
+            ->push(['user_info' => ['status' => 'Active']], 200),
+    ]);
+    config(['xtream.rate_limit_cooldown' => 60]);
+
+    $service = XtreamService::make(playlist: $this->playlist, retryLimit: 1);
+    expect(fn () => $service->userInfo())->toThrow(Exception::class);
+
+    $this->travel(61)->seconds();
+
+    expect($service->userInfo()['user_info']['status'])->toBe('Active');
+    Http::assertSentCount(2);
+});
+
+it('keeps retrying on other errors', function () {
+    Http::fake(['*' => Http::response('Error', 500)]);
+
+    $service = XtreamService::make(playlist: $this->playlist, retryLimit: 2);
+
+    expect(fn () => $service->userInfo())->toThrow(Exception::class);
+    Http::assertSentCount(2);
+});


### PR DESCRIPTION
## Problem

`XtreamService::attemptCall()` treats a `429 Too Many Requests` like any other failure: retry up to `retryLimit` times with a one-second pause, then walk the fallback URLs with the same credentials. Against a rate limit that is exactly the wrong move — every retry feeds the limit.

Measured on a real provider: a series metadata pass hit the limit after ~30 seconds, and the retries then kept the account throttled for **1 h 22**. During that window nothing on the playlist worked: metadata fetches, and through `create_link`, playback on every client — even of content already cached locally.

## Fix

On a 429, the provider host is marked rate limited in the cache for `config('xtream.rate_limit_cooldown')` seconds (default 900, env `XTREAM_RATE_LIMIT_COOLDOWN`). While the circuit is open:

- `call()` throws **before** touching the network — no retry, whatever `retryLimit` is;
- fallback URLs are skipped — the limit is per account, and fallbacks share the account;
- the state lives in the cache, so every worker, request and artisan command respects it.

Other errors keep the existing retry / fallback behaviour untouched. Three small protected methods (`rateLimitKey`, `markRateLimited`, `throwIfRateLimited`), one config key, one `Log::warning` when the circuit opens.

## Tests

`tests/Feature/XtreamRateLimitCircuitBreakerTest.php` — 5 Pest cases:
- a single request goes out on 429 despite `retryLimit: 3`;
- further calls are refused without network while limited — including from a fresh instance;
- no fallback URL is tried on 429;
- calls go through again once the cooldown has elapsed (`travel`);
- 500 keeps retrying (non-regression).

`XtreamFallbackUrlsTest` (18 cases) stays green. Pint (Laravel preset) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rz7Kxw3GqveuW5dBhK14Rq
