### PR TITLE
fix(reclassify): keep DVR VOD channels and DVR Series in their DVR Recordings group/category

### DIFF
--- a/app/Services/GenreGroupReclassifyService.php
+++ b/app/Services/GenreGroupReclassifyService.php
@@ -46,10 +46,15 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
  *     `dvr_recording_id IS NOT NULL` and Series with `import_batch_no = 'dvr'`
  *     are created by DvrVodIntegrationService inside a dedicated "DVR Recordings"
  *     group / category. Re-routing them by TMDB genre would silently break the
- *     user's expectation that DVR content stays in its own bucket — and the
+ *     user's expectation that DVR content stays in its own bucket, and the
  *     TMDB genre for a one-off recording is rarely meaningful anyway (often a
  *     news/sports programme with no movie/tv-genre match). Excluded at query
  *     level so they don't appear in `moved` / `protected` counters.
+ *     Note: `import_batch_no = 'dvr'` is only set on DvrVodIntegrationService's
+ *     Series::create() path. A provider-imported series that later gets a DVR
+ *     episode attached keeps its original batch number and stays eligible for
+ *     reclassification - correct, since that series lives in its provider
+ *     category, not "DVR Recordings".
  *
  * Performance: iteration is via `chunkById(100, ...)` (mirrors FetchTmdbIds.php's
  * own pattern - `cursor()` would risk "database is locked" on SQLite), and groups /
@@ -279,7 +284,10 @@ class GenreGroupReclassifyService
             // DVR-created Series (import_batch_no = 'dvr') live in the "DVR Recordings"
             // category and are owned by DvrVodIntegrationService. Excluded from
             // reclassification so they stay where the user expects them. See class
-            // docblock.
+            // docblock. `series.import_batch_no` is NOT NULL at the schema level, so a
+            // bare `!= 'dvr'` needs no `whereNull(...)->orWhere(...)` guard (contrast
+            // the 2026_09_04 cleanup_series_with_no_source_series_id migration, which
+            // guards it defensively).
             ->where('import_batch_no', '!=', 'dvr')
             ->select(['id', 'playlist_id', 'category_id', 'genre'])
             ->orderBy('id')

--- a/app/Services/GenreGroupReclassifyService.php
+++ b/app/Services/GenreGroupReclassifyService.php
@@ -42,6 +42,14 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
  *     auto_sync_to_custom_config with type 'vod_groups' / 'series_categories' AND
  *     group_filter = 'selected'. group_filter = 'new_only' rules carry no static
  *     group list and are out of scope (documented gap).
+ *   - DVR-created content (out of scope, not "user-protected"). Channels with
+ *     `dvr_recording_id IS NOT NULL` and Series with `import_batch_no = 'dvr'`
+ *     are created by DvrVodIntegrationService inside a dedicated "DVR Recordings"
+ *     group / category. Re-routing them by TMDB genre would silently break the
+ *     user's expectation that DVR content stays in its own bucket — and the
+ *     TMDB genre for a one-off recording is rarely meaningful anyway (often a
+ *     news/sports programme with no movie/tv-genre match). Excluded at query
+ *     level so they don't appear in `moved` / `protected` counters.
  *
  * Performance: iteration is via `chunkById(100, ...)` (mirrors FetchTmdbIds.php's
  * own pattern - `cursor()` would risk "database is locked" on SQLite), and groups /
@@ -105,11 +113,15 @@ class GenreGroupReclassifyService
         // Iterate enabled VOD channels in chunks. Uncategorized is an eligible source
         // group: channels already parked there with genre data get re-evaluated and
         // routed out. Disabled channels are deliberately skipped - see class docblock.
+        // DVR-created channels (dvr_recording_id IS NOT NULL) are excluded entirely -
+        // they're owned by DvrVodIntegrationService and live in the "DVR Recordings"
+        // group, which re-routing would silently empty. See class docblock.
         Channel::query()
             ->where('playlist_id', $playlist->id)
             ->where('is_vod', true)
             ->where('enabled', true)
             ->whereNotNull('group_id')
+            ->whereNull('dvr_recording_id')
             ->select(['id', 'playlist_id', 'group_id', 'group', 'group_internal', 'info'])
             ->orderBy('id')
             ->chunkById(100, function ($channels) use (
@@ -264,6 +276,11 @@ class GenreGroupReclassifyService
             ->where('playlist_id', $playlist->id)
             ->where('enabled', true)
             ->whereNotNull('category_id')
+            // DVR-created Series (import_batch_no = 'dvr') live in the "DVR Recordings"
+            // category and are owned by DvrVodIntegrationService. Excluded from
+            // reclassification so they stay where the user expects them. See class
+            // docblock.
+            ->where('import_batch_no', '!=', 'dvr')
             ->select(['id', 'playlist_id', 'category_id', 'genre'])
             ->orderBy('id')
             ->chunkById(100, function ($seriesItems) use (

--- a/tests/Feature/GenreGroupReclassifyTest.php
+++ b/tests/Feature/GenreGroupReclassifyTest.php
@@ -861,7 +861,7 @@ it('does not reclassify a VOD channel created from a DVR recording', function ()
         'is_vod' => true,
         'is_custom' => true,
         'dvr_recording_id' => $recording->id,
-        // Genre present — without the fix this would have routed the channel
+        // Genre present - without the fix this would have routed the channel
         // out of "DVR Recordings" into the "Action" group.
         'info' => ['genre' => 'Action'],
     ]);
@@ -871,7 +871,7 @@ it('does not reclassify a VOD channel created from a DVR recording', function ()
     expect($result['moved'])->toBe(0)
         ->and($result['protected'])->toBe(0)
         ->and((int) refreshChannel($dvrCh)->group_id)->toBe((int) $dvrGroup->id)
-        // The pre-existing "Action" group must have stayed empty — reclassify
+        // The pre-existing "Action" group must have stayed empty - reclassify
         // must not have created a duplicate or moved anyone into it.
         ->and(Channel::where('group_id', $action->id)->count())->toBe(0);
 });
@@ -888,7 +888,7 @@ it('does not reclassify a Series created from a DVR recording (import_batch_no =
     ]);
     $recording = DvrRecording::factory()->for($this->user)->create();
     // DvrVodIntegrationService::findOrCreateSeries sets this marker on every
-    // DVR-created series — that's the reclassify exclusion key.
+    // DVR-created series - that's the reclassify exclusion key.
     $dvrSeries = enabledSeries($this->playlist, $dvrCategory, $this->user, [
         'import_batch_no' => 'dvr',
         'genre' => 'Drama',
@@ -950,7 +950,7 @@ it('excludes DVR content but still reclassifies regular content on the same play
         ->and($seriesResult['moved'])->toBe(1)
         ->and((int) refreshChannel($regularCh)->group_id)->toBe((int) $actionGroup->id)
         ->and((int) $regularSeries->refresh()->category_id)->toBe((int) $dramaCategory->id)
-        // DVR content untouched — still in their dedicated group / category.
+        // DVR content untouched - still in their dedicated group / category.
         ->and((int) refreshChannel($dvrCh)->group_id)->toBe((int) $dvrGroup->id)
         ->and((int) $dvrSeries->refresh()->category_id)->toBe((int) $dvrCategory->id);
 });

--- a/tests/Feature/GenreGroupReclassifyTest.php
+++ b/tests/Feature/GenreGroupReclassifyTest.php
@@ -1,10 +1,12 @@
 <?php
 
+use App\Events\DvrRecordingStatusEvent;
 use App\Filament\Resources\VodGroups\Pages\EditVodGroup;
 use App\Filament\Resources\VodGroups\Pages\ListVodGroups;
 use App\Jobs\FetchTmdbIds;
 use App\Models\Category;
 use App\Models\Channel;
+use App\Models\DvrRecording;
 use App\Models\Group;
 use App\Models\Playlist;
 use App\Models\Series;
@@ -14,6 +16,7 @@ use App\Services\TmdbService;
 use Filament\Actions\Testing\TestAction;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Livewire\Livewire;
 
@@ -826,4 +829,128 @@ it('Series toggle on, VOD toggle off: reclassifies Series categories but leaves 
         ->and((int) $series->refresh()->category_id)->toBe((int) $actionCategory->id)
         // VOD channel must NOT have moved — its group is still the original $vodSrc
         ->and((int) refreshChannel($vodCh)->group_id)->toBe((int) $vodSrc->id);
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// DVR-created content exclusion tests
+//
+// DvrVodIntegrationService places every DVR VOD channel in a per-playlist
+// "DVR Recordings" group and every DVR-created Series in a per-playlist
+// "DVR Recordings" category. Re-routing them by TMDB genre would silently empty
+// that bucket on every sync. The reclassify service must leave them alone.
+// ────────────────────────────────────────────────────────────────────────────
+
+it('does not reclassify a VOD channel created from a DVR recording', function () {
+    mockTmdbForGenreTest();
+
+    // DvrRecording's `created` listener broadcasts a status event over Reverb
+    // which requires Redis; scope the fake so other listeners stay live.
+    Event::fake([DvrRecordingStatusEvent::class]);
+
+    $dvrGroup = Group::factory()->for($this->user)->for($this->playlist)->create([
+        'type' => 'vod', 'name' => 'DVR Recordings',
+    ]);
+    // Pre-existing genre-named group proves the bug's blast radius: a DVR
+    // channel with TMDB-detectable genre would have been moved here pre-fix.
+    $action = Group::factory()->for($this->user)->for($this->playlist)->create([
+        'type' => 'vod', 'name' => 'Action',
+    ]);
+
+    $recording = DvrRecording::factory()->for($this->user)->create();
+    $dvrCh = enabledChannel($this->playlist, $dvrGroup, $this->user, [
+        'is_vod' => true,
+        'is_custom' => true,
+        'dvr_recording_id' => $recording->id,
+        // Genre present — without the fix this would have routed the channel
+        // out of "DVR Recordings" into the "Action" group.
+        'info' => ['genre' => 'Action'],
+    ]);
+
+    $result = GenreGroupReclassifyService::reclassifyVodGroups($this->playlist);
+
+    expect($result['moved'])->toBe(0)
+        ->and($result['protected'])->toBe(0)
+        ->and((int) refreshChannel($dvrCh)->group_id)->toBe((int) $dvrGroup->id)
+        // The pre-existing "Action" group must have stayed empty — reclassify
+        // must not have created a duplicate or moved anyone into it.
+        ->and(Channel::where('group_id', $action->id)->count())->toBe(0);
+});
+
+it('does not reclassify a Series created from a DVR recording (import_batch_no = dvr)', function () {
+    mockTmdbForGenreTest();
+
+    // See note above: fake the broadcast-only event so DvrRecording creation
+    // doesn't try to talk to Redis.
+    Event::fake([DvrRecordingStatusEvent::class]);
+
+    $dvrCategory = Category::factory()->for($this->user)->for($this->playlist)->create([
+        'name' => 'DVR Recordings',
+    ]);
+    $recording = DvrRecording::factory()->for($this->user)->create();
+    // DvrVodIntegrationService::findOrCreateSeries sets this marker on every
+    // DVR-created series — that's the reclassify exclusion key.
+    $dvrSeries = enabledSeries($this->playlist, $dvrCategory, $this->user, [
+        'import_batch_no' => 'dvr',
+        'genre' => 'Drama',
+    ]);
+
+    $result = GenreGroupReclassifyService::reclassifyCategories($this->playlist);
+
+    expect($result['moved'])->toBe(0)
+        ->and($result['protected'])->toBe(0)
+        ->and((int) $dvrSeries->refresh()->category_id)->toBe((int) $dvrCategory->id)
+        ->and(Category::where('name', 'Drama')->where('playlist_id', $this->playlist->id)->exists())->toBeFalse();
+});
+
+it('excludes DVR content but still reclassifies regular content on the same playlist', function () {
+    mockTmdbForGenreTest();
+
+    Event::fake([DvrRecordingStatusEvent::class]);
+
+    $dvrGroup = Group::factory()->for($this->user)->for($this->playlist)->create([
+        'type' => 'vod', 'name' => 'DVR Recordings',
+    ]);
+    $dvrCategory = Category::factory()->for($this->user)->for($this->playlist)->create([
+        'name' => 'DVR Recordings',
+    ]);
+    $srcVod = Group::factory()->for($this->user)->for($this->playlist)->create(['type' => 'vod', 'name' => 'Whatever']);
+    $srcSeries = Category::factory()->for($this->user)->for($this->playlist)->create(['name' => 'Whatever']);
+
+    $recording = DvrRecording::factory()->for($this->user)->create();
+    $dvrCh = enabledChannel($this->playlist, $dvrGroup, $this->user, [
+        'is_vod' => true,
+        'dvr_recording_id' => $recording->id,
+        'info' => ['genre' => 'Action'],
+    ]);
+    $dvrSeries = enabledSeries($this->playlist, $dvrCategory, $this->user, [
+        'import_batch_no' => 'dvr',
+        'genre' => 'Drama',
+    ]);
+
+    $regularCh = enabledChannel($this->playlist, $srcVod, $this->user, [
+        'is_vod' => true,
+        'dvr_recording_id' => null,
+        'info' => ['genre' => 'Action'],
+    ]);
+    $regularSeries = enabledSeries($this->playlist, $srcSeries, $this->user, [
+        'import_batch_no' => 'whatever',
+        'genre' => 'Drama',
+    ]);
+
+    $vodResult = GenreGroupReclassifyService::reclassifyVodGroups($this->playlist);
+    $seriesResult = GenreGroupReclassifyService::reclassifyCategories($this->playlist);
+
+    $actionGroup = Group::where('name', 'Action')->where('type', 'vod')->where('playlist_id', $this->playlist->id)->first();
+    $dramaCategory = Category::where('name', 'Drama')->where('playlist_id', $this->playlist->id)->first();
+
+    // Regular content moved, DVR content stayed put.
+    expect($actionGroup)->not->toBeNull()
+        ->and($dramaCategory)->not->toBeNull()
+        ->and($vodResult['moved'])->toBe(1)
+        ->and($seriesResult['moved'])->toBe(1)
+        ->and((int) refreshChannel($regularCh)->group_id)->toBe((int) $actionGroup->id)
+        ->and((int) $regularSeries->refresh()->category_id)->toBe((int) $dramaCategory->id)
+        // DVR content untouched — still in their dedicated group / category.
+        ->and((int) refreshChannel($dvrCh)->group_id)->toBe((int) $dvrGroup->id)
+        ->and((int) $dvrSeries->refresh()->category_id)->toBe((int) $dvrCategory->id);
 });


### PR DESCRIPTION
## Summary

`GenreGroupReclassifyService::reclassifyVodGroups()` and `reclassifyCategories()` were iterating **every** enabled VOD channel and Series and re-routing them by TMDB genre — including content created by `DvrVodIntegrationService`, which places DVR-created VOD channels in a dedicated `DVR Recordings` group and DVR-created Series in a dedicated `DVR Recordings` category.

Every TMDB sync silently yanked DVR recordings out into genre-named buckets, breaking the user's expectation that they stay put.

## Fix

Two query-level filter additions in `app/Services/GenreGroupReclassifyService.php`:

- **VOD channels:** `->whereNull('dvr_recording_id')` — `DvrVodIntegrationService::integrateAsMovie()` sets `Channel.dvr_recording_id = $recording->id` on every movie integration.
- **Series:** `->where('import_batch_no', '!=', 'dvr')` — Series has no direct `dvr_recording_id` FK (only `Episode` does); `import_batch_no = 'dvr'` is the canonical DVR-side marker set by `DvrVodIntegrationService::findOrCreateSeries()`.

Excluded at the query layer rather than counted in `protected` because DVR content is **out of scope**, not user-configured as protected. The existing `moved` / `protected` counters keep their existing semantics.

## Tests

3 new tests in `tests/Feature/GenreGroupReclassifyTest.php` (122 assertions total, all passing):

1. DVR VOD channel stays in `DVR Recordings` group even with matching TMDB genre and pre-existing genre-named group present.
2. DVR Series (`import_batch_no = 'dvr'`) stays in `DVR Recordings` category.
3. Mixed playlist — regular VOD channels and Series reclassify normally; DVR content untouched. Proves the filter is surgical.

```
vendor/bin/pest tests/Feature/GenreGroupReclassifyTest.php
Tests: 35 passed (122 assertions)
```

## Pre-PR checklist

- [x] Security scan: `composer security:scan` run. 4 pre-existing advisories flagged in `league/commonmark` (a dev dependency used for docs rendering). Not introduced by this change — locked version (`composer audit --locked`) is clean. Tracked separately; out of scope for this fix.
- [x] Lang files: N/A — no user-facing strings changed (no Blade view, Filament label, validation message, or mail subject altered).
- [x] Pint: `vendor/bin/pint --test` on changed files → passed.

## Diff stats

```
 app/Services/GenreGroupReclassifyService.php |  17 ++++
 tests/Feature/GenreGroupReclassifyTest.php   | 127 +++++++++++++++++++++++++++
 2 files changed, 144 insertions(+)
```