### PR TITLE
feat(playlists): add Rating sort to Sort Alpha Configs

### DIFF
--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -2922,15 +2922,15 @@ class PlaylistResource extends Resource implements CopilotResource
                                     ];
 
                                     return match ($get('target')) {
-                                        'series_categories' => ['release_date' => 'Release Date'],
-                                        'vod_groups' => [...$alphaOptions, 'release_date' => 'Release Date'],
+                                        'series_categories' => ['release_date' => 'Release Date', 'rating' => 'Rating'],
+                                        'vod_groups' => [...$alphaOptions, 'release_date' => 'Release Date', 'rating' => 'Rating'],
                                         default => $alphaOptions,
                                     };
                                 })
                                 ->live()
                                 ->default('title')
                                 ->required()
-                                ->afterStateUpdated(fn (Set $set, ?string $state) => $set('sort', ($state ?? '') === 'release_date' ? 'DESC' : 'ASC'))
+                                ->afterStateUpdated(fn (Set $set, ?string $state) => $set('sort', in_array($state, ['release_date', 'rating'], true) ? 'DESC' : 'ASC'))
                                 ->columnSpan(2),
                             Select::make('sort')
                                 ->label(__('Sort Order'))

--- a/app/Jobs/RunPlaylistSortAlpha.php
+++ b/app/Jobs/RunPlaylistSortAlpha.php
@@ -68,6 +68,13 @@ class RunPlaylistSortAlpha implements ShouldQueue
                     continue;
                 }
 
+                if ($column === 'rating' && $isAll) {
+                    SortFacade::bulkSortPlaylistVodByRating($this->playlist, $order);
+                    $vodRulesRun++;
+
+                    continue;
+                }
+
                 $query = $this->playlist->vodGroups();
                 if (! $isAll) {
                     $query = $query->whereIn('name_internal', $selectedGroups);
@@ -75,6 +82,8 @@ class RunPlaylistSortAlpha implements ShouldQueue
                 $query->each(function ($group) use ($column, $order): void {
                     if ($column === 'release_date') {
                         SortFacade::bulkSortGroupChannelsByReleaseDate($group, $order);
+                    } elseif ($column === 'rating') {
+                        SortFacade::bulkSortGroupChannelsByRating($group, $order);
                     } else {
                         SortFacade::bulkSortGroupChannels($group, $order, $column);
                     }
@@ -89,6 +98,16 @@ class RunPlaylistSortAlpha implements ShouldQueue
                             ->whereIn('name_internal', $selectedGroups)
                             ->each(function ($category) use ($order): void {
                                 SortFacade::bulkSortCategorySeriesByReleaseDate($category, $order);
+                            });
+                    }
+                } elseif ($column === 'rating') {
+                    if ($isAll) {
+                        SortFacade::bulkSortPlaylistSeriesByRating($this->playlist, $order);
+                    } else {
+                        $this->playlist->categories()
+                            ->whereIn('name_internal', $selectedGroups)
+                            ->each(function ($category) use ($order): void {
+                                SortFacade::bulkSortCategorySeriesByRating($category, $order);
                             });
                     }
                 }

--- a/app/Services/SortService.php
+++ b/app/Services/SortService.php
@@ -448,6 +448,207 @@ class SortService
     }
 
     /**
+     * Bulk-update VOD channels' sort order within a group by rating.
+     * Rows without a rating (NULL) always sort last, regardless of direction.
+     */
+    public function bulkSortGroupChannelsByRating(Group $record, string $order = 'DESC'): void
+    {
+        $direction = strtoupper($order) === 'DESC' ? 'DESC' : 'ASC';
+        $driver = DB::getPdo()->getAttribute(\PDO::ATTR_DRIVER_NAME);
+
+        $expression = "rating_5based IS NULL, rating_5based {$direction}";
+
+        if ($driver === 'mysql' || $driver === 'mariadb') {
+            DB::statement("UPDATE channels c JOIN (SELECT id, ROW_NUMBER() OVER (ORDER BY {$expression}) AS rn FROM channels WHERE group_id = ?) t ON c.id = t.id SET c.sort = t.rn", [$record->id]);
+
+            return;
+        }
+
+        if ($this->isPostgres($driver)) {
+            DB::statement("UPDATE channels SET sort = t.rn FROM (SELECT id, ROW_NUMBER() OVER (ORDER BY {$expression}) AS rn FROM channels WHERE group_id = ?) t WHERE channels.id = t.id", [$record->id]);
+
+            return;
+        }
+
+        if ($driver === 'sqlite') {
+            DB::statement("WITH ranked AS (SELECT id, ROW_NUMBER() OVER (ORDER BY {$expression}) AS rn FROM channels WHERE group_id = ?) UPDATE channels SET sort = (SELECT rn FROM ranked WHERE ranked.id = channels.id) WHERE group_id = ?", [$record->id, $record->id]);
+
+            return;
+        }
+
+        // Fallback: CASE update
+        $ids = $record->channels()->orderByRaw("rating_5based IS NULL, rating_5based {$direction}")->pluck('id')->all();
+        if (empty($ids)) {
+            return;
+        }
+
+        $cases = [];
+        $i = 1;
+        foreach ($ids as $id) {
+            $cases[] = "WHEN {$id} THEN {$i}";
+            $i++;
+        }
+
+        $casesSql = implode(' ', $cases);
+        $idsSql = implode(',', $ids);
+
+        DB::statement("UPDATE channels SET sort = CASE id {$casesSql} END WHERE id IN ({$idsSql})");
+    }
+
+    /**
+     * Bulk-update series' sort order within a category by rating.
+     * Rows without a rating (NULL) always sort last, regardless of direction.
+     */
+    public function bulkSortCategorySeriesByRating(Category $record, string $order = 'DESC'): void
+    {
+        $direction = strtoupper($order) === 'DESC' ? 'DESC' : 'ASC';
+        $driver = DB::getPdo()->getAttribute(\PDO::ATTR_DRIVER_NAME);
+
+        $expression = "rating_5based IS NULL, rating_5based {$direction}";
+
+        if ($driver === 'mysql' || $driver === 'mariadb') {
+            DB::statement("UPDATE series s JOIN (SELECT id, ROW_NUMBER() OVER (ORDER BY {$expression}) AS rn FROM series WHERE category_id = ?) t ON s.id = t.id SET s.sort = t.rn", [$record->id]);
+
+            return;
+        }
+
+        if ($this->isPostgres($driver)) {
+            DB::statement("UPDATE series SET sort = t.rn FROM (SELECT id, ROW_NUMBER() OVER (ORDER BY {$expression}) AS rn FROM series WHERE category_id = ?) t WHERE series.id = t.id", [$record->id]);
+
+            return;
+        }
+
+        if ($driver === 'sqlite') {
+            DB::statement("WITH ranked AS (SELECT id, ROW_NUMBER() OVER (ORDER BY {$expression}) AS rn FROM series WHERE category_id = ?) UPDATE series SET sort = (SELECT rn FROM ranked WHERE ranked.id = series.id) WHERE category_id = ?", [$record->id, $record->id]);
+
+            return;
+        }
+
+        // Fallback: CASE update
+        $ids = $record->series()->orderByRaw("rating_5based IS NULL, rating_5based {$direction}")->pluck('id')->all();
+        if (empty($ids)) {
+            return;
+        }
+
+        $cases = [];
+        $i = 1;
+        foreach ($ids as $id) {
+            $cases[] = "WHEN {$id} THEN {$i}";
+            $i++;
+        }
+
+        $casesSql = implode(' ', $cases);
+        $idsSql = implode(',', $ids);
+
+        DB::statement("UPDATE series SET sort = CASE id {$casesSql} END WHERE id IN ({$idsSql})");
+    }
+
+    /**
+     * Sort ALL VOD channels in a playlist globally by rating.
+     * Assigns unique sort numbers 1..N across all groups so there are no collisions.
+     * Rows without a rating (NULL) always sort last, regardless of direction.
+     */
+    public function bulkSortPlaylistVodByRating(Playlist $playlist, string $order = 'DESC'): void
+    {
+        $direction = strtoupper($order) === 'DESC' ? 'DESC' : 'ASC';
+        $driver = DB::getPdo()->getAttribute(\PDO::ATTR_DRIVER_NAME);
+
+        $expression = "rating_5based IS NULL, rating_5based {$direction}";
+
+        if ($driver === 'mysql' || $driver === 'mariadb') {
+            DB::statement("UPDATE channels c JOIN (SELECT id, ROW_NUMBER() OVER (ORDER BY {$expression}) AS rn FROM channels WHERE playlist_id = ? AND is_vod = 1) t ON c.id = t.id SET c.sort = t.rn", [$playlist->id]);
+
+            return;
+        }
+
+        if ($this->isPostgres($driver)) {
+            DB::statement("UPDATE channels SET sort = t.rn FROM (SELECT id, ROW_NUMBER() OVER (ORDER BY {$expression}) AS rn FROM channels WHERE playlist_id = ? AND is_vod = true) t WHERE channels.id = t.id", [$playlist->id]);
+
+            return;
+        }
+
+        if ($driver === 'sqlite') {
+            DB::statement("WITH ranked AS (SELECT id, ROW_NUMBER() OVER (ORDER BY {$expression}) AS rn FROM channels WHERE playlist_id = ? AND is_vod = 1) UPDATE channels SET sort = (SELECT rn FROM ranked WHERE ranked.id = channels.id) WHERE playlist_id = ? AND is_vod = 1", [$playlist->id, $playlist->id]);
+
+            return;
+        }
+
+        // Fallback: ORDER BY SELECT then CASE update
+        $ids = Channel::where('playlist_id', $playlist->id)
+            ->where('is_vod', true)
+            ->orderByRaw("rating_5based IS NULL, rating_5based {$direction}")
+            ->pluck('id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+
+        if (empty($ids)) {
+            return;
+        }
+
+        $cases = [];
+        foreach ($ids as $i => $id) {
+            $cases[] = "WHEN {$id} THEN ".($i + 1);
+        }
+
+        $casesSql = implode(' ', $cases);
+        $idsSql = implode(',', $ids);
+
+        DB::statement("UPDATE channels SET sort = CASE id {$casesSql} END WHERE id IN ({$idsSql})");
+    }
+
+    /**
+     * Sort ALL series in a playlist globally by rating.
+     * Assigns unique sort numbers 1..N across all categories so there are no collisions.
+     * Rows without a rating (NULL) always sort last, regardless of direction.
+     */
+    public function bulkSortPlaylistSeriesByRating(Playlist $playlist, string $order = 'DESC'): void
+    {
+        $direction = strtoupper($order) === 'DESC' ? 'DESC' : 'ASC';
+        $driver = DB::getPdo()->getAttribute(\PDO::ATTR_DRIVER_NAME);
+
+        $expression = "rating_5based IS NULL, rating_5based {$direction}";
+
+        if ($driver === 'mysql' || $driver === 'mariadb') {
+            DB::statement("UPDATE series s JOIN (SELECT id, ROW_NUMBER() OVER (ORDER BY {$expression}) AS rn FROM series WHERE playlist_id = ?) t ON s.id = t.id SET s.sort = t.rn", [$playlist->id]);
+
+            return;
+        }
+
+        if ($this->isPostgres($driver)) {
+            DB::statement("UPDATE series SET sort = t.rn FROM (SELECT id, ROW_NUMBER() OVER (ORDER BY {$expression}) AS rn FROM series WHERE playlist_id = ?) t WHERE series.id = t.id", [$playlist->id]);
+
+            return;
+        }
+
+        if ($driver === 'sqlite') {
+            DB::statement("WITH ranked AS (SELECT id, ROW_NUMBER() OVER (ORDER BY {$expression}) AS rn FROM series WHERE playlist_id = ?) UPDATE series SET sort = (SELECT rn FROM ranked WHERE ranked.id = series.id) WHERE playlist_id = ?", [$playlist->id, $playlist->id]);
+
+            return;
+        }
+
+        // Fallback: ORDER BY SELECT then CASE update
+        $ids = Series::where('playlist_id', $playlist->id)
+            ->orderByRaw("rating_5based IS NULL, rating_5based {$direction}")
+            ->pluck('id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+
+        if (empty($ids)) {
+            return;
+        }
+
+        $cases = [];
+        foreach ($ids as $i => $id) {
+            $cases[] = "WHEN {$id} THEN ".($i + 1);
+        }
+
+        $casesSql = implode(' ', $cases);
+        $idsSql = implode(',', $ids);
+
+        DB::statement("UPDATE series SET sort = CASE id {$casesSql} END WHERE id IN ({$idsSql})");
+    }
+
+    /**
      * Bulk recount channel numbers.
      *
      * When $activeOnly is true, only enabled channels are renumbered via SQL;

--- a/config/checkpoint.php
+++ b/config/checkpoint.php
@@ -263,6 +263,31 @@ return [
         '53e3187b2a5f',
         'a215f7e698e0',
 
+        // SortService rating-sort methods: same guarantees as the release-date
+        // methods above — $expression is a compile-time SQL constant
+        // ("rating_5based IS NULL, rating_5based {$direction}") with a hardcoded
+        // column name and a ternary-validated $direction ('ASC'|'DESC'); $table and
+        // the WHERE clause are hardcoded literals with ? placeholders bound to
+        // existing DB primary keys. No user input reaches the interpolated SQL.
+        '4a1682e93f25',
+        'c12738aab5ff',
+        '81e30ea0dc34',
+        'cb9e8d47448c',
+        '415d1affe987',
+        'ec805cca58a8',
+        'd57f12822690',
+        'cc59da459115',
+        // playlist-level variants (bulkSortPlaylistVodByRating /
+        // bulkSortPlaylistSeriesByRating): mysql/pgsql/sqlite/fallback branches
+        // hit the same hardcoded-SQL + bound-placeholder guarantee. The SQLite
+        // branches repeat the WHERE clause so they produce distinct hashes;
+        // the fallback orderByRaw() calls share one hash. Still no user input
+        // reaches the interpolated SQL.
+        'ac8931725930',
+        '88053eeb4c28',
+        '7afdcc058548',
+        '21c185a4fbbc',
+
         // SortService natural-sort rewrite (issue #1369): same guarantees as the
         // original SortService entries above, just on new lines/hashes.
         // $orderByColumn/$fallbackOrderByColumn come from a match() that throws

--- a/tests/Feature/PlaylistSortAlphaConfigTest.php
+++ b/tests/Feature/PlaylistSortAlphaConfigTest.php
@@ -56,12 +56,14 @@ it('offers only valid sort columns for each target', function (string $target, a
             'stream_id' => 'ID (or override if set)',
             'channel' => 'Channel No.',
             'release_date' => 'Release Date',
+            'rating' => 'Rating',
         ],
     ],
     'series categories' => [
         'series_categories',
         [
             'release_date' => 'Release Date',
+            'rating' => 'Rating',
         ],
     ],
 ]);

--- a/tests/Feature/RunPlaylistSortAlphaTest.php
+++ b/tests/Feature/RunPlaylistSortAlphaTest.php
@@ -292,6 +292,176 @@ it('sorts only selected series categories by release date', function () {
         ->toBe(['Newer unselected', 'Older unselected']);
 });
 
+it('sorts all vod groups by rating across the playlist', function () {
+    $this->playlist->update([
+        'sort_alpha_config' => [
+            ['enabled' => true, 'target' => 'vod_groups', 'group' => ['all'], 'column' => 'rating', 'sort' => 'DESC'],
+        ],
+    ]);
+
+    $firstGroup = Group::factory()->for($this->playlist)->for($this->user)->create(['type' => 'vod']);
+    $low = Channel::factory()->for($this->user)->for($this->playlist)->for($firstGroup)->create([
+        'title' => 'Low',
+        'is_vod' => true,
+        'rating_5based' => 3.0,
+        'sort' => 1,
+    ]);
+    $high = Channel::factory()->for($this->user)->for($this->playlist)->for($firstGroup)->create([
+        'title' => 'High',
+        'is_vod' => true,
+        'rating_5based' => 8.5,
+        'sort' => 2,
+    ]);
+
+    $secondGroup = Group::factory()->for($this->playlist)->for($this->user)->create(['type' => 'vod']);
+    $middle = Channel::factory()->for($this->user)->for($this->playlist)->for($secondGroup)->create([
+        'title' => 'Middle',
+        'is_vod' => true,
+        'rating_5based' => 5.0,
+        'sort' => 1,
+    ]);
+    $unrated = Channel::factory()->for($this->user)->for($this->playlist)->for($secondGroup)->create([
+        'title' => 'Unrated',
+        'is_vod' => true,
+        'rating_5based' => null,
+        'sort' => 2,
+    ]);
+
+    (new RunPlaylistSortAlpha($this->playlist))->handle();
+
+    expect($this->playlist->vod_channels()->orderBy('sort')->pluck('id')->all())
+        ->toBe([$high->id, $middle->id, $low->id, $unrated->id]);
+});
+
+it('sorts only selected vod groups by rating', function () {
+    $this->playlist->update([
+        'sort_alpha_config' => [
+            ['enabled' => true, 'target' => 'vod_groups', 'group' => ['Selected VOD'], 'column' => 'rating', 'sort' => 'DESC'],
+        ],
+    ]);
+
+    $selectedGroup = Group::factory()->for($this->playlist)->for($this->user)->create([
+        'type' => 'vod',
+        'name_internal' => 'Selected VOD',
+    ]);
+    Channel::factory()->for($this->user)->for($this->playlist)->for($selectedGroup)->create([
+        'title' => 'Lower selected',
+        'is_vod' => true,
+        'rating_5based' => 2.0,
+        'sort' => 1,
+    ]);
+    Channel::factory()->for($this->user)->for($this->playlist)->for($selectedGroup)->create([
+        'title' => 'Higher selected',
+        'is_vod' => true,
+        'rating_5based' => 9.0,
+        'sort' => 2,
+    ]);
+
+    $unselectedGroup = Group::factory()->for($this->playlist)->for($this->user)->create([
+        'type' => 'vod',
+        'name_internal' => 'Unselected VOD',
+    ]);
+    Channel::factory()->for($this->user)->for($this->playlist)->for($unselectedGroup)->create([
+        'title' => 'Higher unselected',
+        'is_vod' => true,
+        'rating_5based' => 9.0,
+        'sort' => 1,
+    ]);
+    Channel::factory()->for($this->user)->for($this->playlist)->for($unselectedGroup)->create([
+        'title' => 'Lower unselected',
+        'is_vod' => true,
+        'rating_5based' => 2.0,
+        'sort' => 2,
+    ]);
+
+    (new RunPlaylistSortAlpha($this->playlist))->handle();
+
+    expect($selectedGroup->channels()->orderBy('sort')->pluck('title')->all())
+        ->toBe(['Higher selected', 'Lower selected'])
+        ->and($unselectedGroup->channels()->orderBy('sort')->pluck('title')->all())
+        ->toBe(['Higher unselected', 'Lower unselected']);
+});
+
+it('sorts all series categories by rating across the playlist', function () {
+    $this->playlist->update([
+        'sort_alpha_config' => [
+            ['enabled' => true, 'target' => 'series_categories', 'group' => ['all'], 'column' => 'rating', 'sort' => 'DESC'],
+        ],
+    ]);
+
+    $firstCategory = Category::factory()->for($this->playlist)->for($this->user)->create();
+    $low = Series::factory()->for($this->user)->for($this->playlist)->for($firstCategory)->create([
+        'name' => 'Low',
+        'rating_5based' => 1,
+        'sort' => 1,
+    ]);
+    $high = Series::factory()->for($this->user)->for($this->playlist)->for($firstCategory)->create([
+        'name' => 'High',
+        'rating_5based' => 5,
+        'sort' => 2,
+    ]);
+
+    $secondCategory = Category::factory()->for($this->playlist)->for($this->user)->create();
+    $middle = Series::factory()->for($this->user)->for($this->playlist)->for($secondCategory)->create([
+        'name' => 'Middle',
+        'rating_5based' => 3,
+        'sort' => 1,
+    ]);
+    $unrated = Series::factory()->for($this->user)->for($this->playlist)->for($secondCategory)->create([
+        'name' => 'Unrated',
+        'rating_5based' => null,
+        'sort' => 2,
+    ]);
+
+    (new RunPlaylistSortAlpha($this->playlist))->handle();
+
+    expect($this->playlist->series()->orderBy('sort')->pluck('id')->all())
+        ->toBe([$high->id, $middle->id, $low->id, $unrated->id]);
+});
+
+it('sorts only selected series categories by rating', function () {
+    $this->playlist->update([
+        'sort_alpha_config' => [
+            ['enabled' => true, 'target' => 'series_categories', 'group' => ['Selected Series'], 'column' => 'rating', 'sort' => 'DESC'],
+        ],
+    ]);
+
+    $selectedCategory = Category::factory()->for($this->playlist)->for($this->user)->create([
+        'name_internal' => 'Selected Series',
+    ]);
+    Series::factory()->for($this->user)->for($this->playlist)->for($selectedCategory)->create([
+        'name' => 'Lower selected',
+        'rating_5based' => 2,
+        'sort' => 1,
+    ]);
+    Series::factory()->for($this->user)->for($this->playlist)->for($selectedCategory)->create([
+        'name' => 'Higher selected',
+        'rating_5based' => 9,
+        'sort' => 2,
+    ]);
+
+    $unselectedCategory = Category::factory()->for($this->playlist)->for($this->user)->create([
+        'name_internal' => 'Unselected Series',
+    ]);
+    Series::factory()->for($this->user)->for($this->playlist)->for($unselectedCategory)->create([
+        'name' => 'Higher unselected',
+        'rating_5based' => 9,
+        'sort' => 1,
+    ]);
+    Series::factory()->for($this->user)->for($this->playlist)->for($unselectedCategory)->create([
+        'name' => 'Lower unselected',
+        'rating_5based' => 2,
+        'sort' => 2,
+    ]);
+
+    (new RunPlaylistSortAlpha($this->playlist))->handle();
+
+    expect($selectedCategory->series()->orderBy('sort')->pluck('name')->all())
+        ->toBe(['Higher selected', 'Lower selected'])
+        ->and($unselectedCategory->series()->orderBy('sort')->pluck('name')->all())
+        ->toBe(['Higher unselected', 'Lower unselected']);
+});
+
 it('summarizes executed live vod and series rules in the notification', function () {
     $this->playlist->update([
         'sort_alpha_config' => [

--- a/tests/Feature/SortServiceTest.php
+++ b/tests/Feature/SortServiceTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use App\Models\Category;
 use App\Models\Channel;
 use App\Models\CustomPlaylist;
 use App\Models\Group;
 use App\Models\Playlist;
+use App\Models\Series;
 use App\Models\User;
 use App\Services\SortService;
 use Illuminate\Support\Facades\DB;
@@ -223,3 +225,86 @@ it('rejects invalid column for custom playlist sort', function () {
 
     $this->service->bulkSortAlphaCustomPlaylistChannels($customPlaylist, $channels, 'ASC', 'created_at');
 })->throws(InvalidArgumentException::class, 'Invalid sort column provided.');
+
+// ---------------------------------------------------------------------------
+// Rating-based sorting (bulkSort*ByRating)
+// ---------------------------------------------------------------------------
+
+it('sorts group channels by rating DESC with nulls last', function () {
+    $vodGroup = Group::factory()->for($this->playlist)->for($this->user)->create(['type' => 'vod']);
+    Channel::factory()->for($this->user)->for($this->playlist)->for($vodGroup)->create(['title' => 'Low', 'rating_5based' => 3.0, 'sort' => 1]);
+    Channel::factory()->for($this->user)->for($this->playlist)->for($vodGroup)->create(['title' => 'Unrated', 'rating_5based' => null, 'sort' => 2]);
+    Channel::factory()->for($this->user)->for($this->playlist)->for($vodGroup)->create(['title' => 'High', 'rating_5based' => 8.5, 'sort' => 3]);
+
+    $this->service->bulkSortGroupChannelsByRating($vodGroup, 'DESC');
+
+    expect($vodGroup->channels()->orderBy('sort')->pluck('title')->toArray())
+        ->toBe(['High', 'Low', 'Unrated']);
+});
+
+it('sorts all playlist VOD channels by rating DESC with nulls last', function () {
+    $firstGroup = Group::factory()->for($this->playlist)->for($this->user)->create(['type' => 'vod']);
+    $low = Channel::factory()->for($this->user)->for($this->playlist)->for($firstGroup)->create([
+        'title' => 'Low',
+        'is_vod' => true,
+        'rating_5based' => 2.5,
+        'sort' => 1,
+    ]);
+
+    $secondGroup = Group::factory()->for($this->playlist)->for($this->user)->create(['type' => 'vod']);
+    $high = Channel::factory()->for($this->user)->for($this->playlist)->for($secondGroup)->create([
+        'title' => 'High',
+        'is_vod' => true,
+        'rating_5based' => 9.0,
+        'sort' => 1,
+    ]);
+    $unrated = Channel::factory()->for($this->user)->for($this->playlist)->for($secondGroup)->create([
+        'title' => 'Unrated',
+        'is_vod' => true,
+        'rating_5based' => null,
+        'sort' => 2,
+    ]);
+
+    $this->service->bulkSortPlaylistVodByRating($this->playlist, 'DESC');
+
+    expect($this->playlist->vod_channels()->orderBy('sort')->pluck('id')->all())
+        ->toBe([$high->id, $low->id, $unrated->id]);
+});
+
+it('sorts category series by rating DESC with nulls last', function () {
+    $category = Category::factory()->for($this->playlist)->for($this->user)->create();
+    Series::factory()->for($this->user)->for($this->playlist)->for($category)->create(['name' => 'Low', 'rating_5based' => 1, 'sort' => 1]);
+    Series::factory()->for($this->user)->for($this->playlist)->for($category)->create(['name' => 'Unrated', 'rating_5based' => null, 'sort' => 2]);
+    Series::factory()->for($this->user)->for($this->playlist)->for($category)->create(['name' => 'High', 'rating_5based' => 5, 'sort' => 3]);
+
+    $this->service->bulkSortCategorySeriesByRating($category, 'DESC');
+
+    expect($category->series()->orderBy('sort')->pluck('name')->toArray())
+        ->toBe(['High', 'Low', 'Unrated']);
+});
+
+it('sorts all playlist series by rating DESC with nulls last', function () {
+    $firstCategory = Category::factory()->for($this->playlist)->for($this->user)->create();
+    $low = Series::factory()->for($this->user)->for($this->playlist)->for($firstCategory)->create([
+        'name' => 'Low',
+        'rating_5based' => 1,
+        'sort' => 1,
+    ]);
+
+    $secondCategory = Category::factory()->for($this->playlist)->for($this->user)->create();
+    $high = Series::factory()->for($this->user)->for($this->playlist)->for($secondCategory)->create([
+        'name' => 'High',
+        'rating_5based' => 5,
+        'sort' => 1,
+    ]);
+    $unrated = Series::factory()->for($this->user)->for($this->playlist)->for($secondCategory)->create([
+        'name' => 'Unrated',
+        'rating_5based' => null,
+        'sort' => 2,
+    ]);
+
+    $this->service->bulkSortPlaylistSeriesByRating($this->playlist, 'DESC');
+
+    expect($this->playlist->series()->orderBy('sort')->pluck('id')->all())
+        ->toBe([$high->id, $low->id, $unrated->id]);
+});


### PR DESCRIPTION
Adds a new **Rating** option to the **Sort By** dropdown inside **Sort Alpha Configs** on a playlist, so you can have your syncs re-sort VOD groups and series categories by user rating instead of only by title or release date.

## Where it lives

The dropdown is on the Playlist resource (`app/Filament/Resources/Playlists/PlaylistResource.php`), inside the collapsible **Sort Alpha Configs** section. That section builds one rule per row — target → sort by → direction — and executes them in order after each sync. The new `rating` value is exposed for **VOD Groups** and **Series Categories** only; live TV channels don't carry ratings, so those are untouched.

Under the hood:

- `app/Services/SortService.php` grew four methods that mirror the existing release-date sorting — per-group and playlist-wide, for both VOD channels (`bulkSortGroupChannelsByRating`, `bulkSortPlaylistVodByRating`) and series (`bulkSortCategorySeriesByRating`, `bulkSortPlaylistSeriesByRating`). They rank rows on the numeric `rating_5based` column using window functions on MySQL/Postgres/SQLite, with a PHP fallback for other drivers.
- `app/Jobs/RunPlaylistSortAlpha.php` now routes `column = rating` to those methods, so it kicks off automatically as part of the same post-sync pipeline as the other sort rules, in rule order.

## What it does

- Sorts by the 5-based rating (`rating_5based`), **highest rated first** by default (Rating defaults to DESC, same as Release Date).
- Rows with **no rating always sink to the bottom** regardless of direction, so unrated content doesn't clutter the top.
- Choosing **All** groups/categories renumbers the whole playlist cleanly 1..N; picking specific groups re-sorts only those.

## What needs to be configured

1. Open a playlist → the **Sort Alpha Configs** section → **Add sort config**.
2. Set **Target** to **VOD Groups** or **Series Categories**.
3. Set **Sort By** to **Rating** (new option).
4. Choose the groups/categories (or All) and the direction — it defaults to highest-first.
5. Run a sync. It executes in order with your other rules and fires the usual "Sort Alpha completed" notification.

## Notes for review

- The new `DB::statement` calls in `SortService` trip the checkpoint scanner's SQL-injection heuristic the same way the existing release-date methods do. They're safe — the direction is validated to ASC/DESC and everything else is a hardcoded literal with `?` placeholders — so I added them to the reviewed false-positive baseline in `config/checkpoint.php`.
- `composer security:scan` still reports 4 high-severity advisories in `league/commonmark` (a transitive dependency of Laravel's markdown support) plus 1 moderate npm advisory (`@xmldom/xmldom`). These are **pre-existing** on `dev` and unrelated to this change — no dependencies were added. Worth a separate bump of `league/commonmark` to `^2.9.1+` to clear them.

## Testing

- 38 Pest tests pass across `SortServiceTest`, `RunPlaylistSortAlphaTest`, and `PlaylistSortAlphaConfigTest`, including 8 new tests covering VOD/series rating sort (all + specific group/category) and nulls-last behavior.
- `vendor/bin/pint` clean on all changed files.
