### PR TITLE
feat(dvr): recording-aware live capacity, DVR-wins eviction, and merged-playlist DVR fixes

### DIFF
--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -4462,12 +4462,18 @@ class XtreamApiController extends Controller
         // outlive its row's Recording status during stop drain) PLUS imminent
         // scheduled recordings (starting within 10 minutes) so rapid-fire
         // taps can't slip past before the previous ones start.
-        $sourceLimit = $channel->playlist instanceof Playlist ? $channel->playlist->available_streams : 0;
+        // Profile-enabled playlists (pooled providers) are EXCLUDED here:
+        // a full pool is handled at start time by the DVR-wins eviction
+        // (the recording evicts an older live stream instead of failing).
+        $sourcePlaylist = $channel->playlist instanceof Playlist ? $channel->playlist : null;
+        $sourceLimit = $sourcePlaylist && ! $sourcePlaylist->profiles_enabled
+            ? $sourcePlaylist->available_streams
+            : 0;
         $effectiveLimit = 0;
         if ($sourceLimit > 0) {
             $effectiveLimit = $sourceLimit;
         }
-        if ($playlist->available_streams > 0) {
+        if (! $sourcePlaylist?->profiles_enabled && $playlist->available_streams > 0) {
             $effectiveLimit = $effectiveLimit === 0
                 ? $playlist->available_streams
                 : min($effectiveLimit, $playlist->available_streams);

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -4834,13 +4834,13 @@ class XtreamApiController extends Controller
             return response()->json(['error' => 'recording_id parameter is required'], 400);
         }
 
-        $dvrSetting = $playlist->dvrSetting;
+        $dvrSettingIds = $this->resolveDvrSettingIds($playlist);
 
-        if (! $dvrSetting) {
+        if ($dvrSettingIds === []) {
             return response()->json(['error' => 'DVR not configured for this playlist'], 404);
         }
 
-        $recording = DvrRecording::where('dvr_setting_id', $dvrSetting->id)
+        $recording = DvrRecording::whereIn('dvr_setting_id', $dvrSettingIds)
             ->where('uuid', $uuid)
             ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
             ->whereIn('status', [

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -4377,6 +4377,21 @@ class XtreamApiController extends Controller
     /**
      * Schedule a one-shot DVR recording rule from the TV app.
      */
+    private function resolveDvrSetting($playlist, ?int $channelId = null): ?\App\Models\DvrSetting
+    {
+        if ($playlist instanceof Playlist && $playlist->dvrSetting?->enabled) {
+            return $playlist->dvrSetting;
+        }
+        if ($channelId && ! $playlist instanceof Playlist) {
+            $channel = $playlist->channels()->where('channels.id', $channelId)->first();
+            if ($channel?->playlist instanceof Playlist && $channel->playlist->dvrSetting?->enabled) {
+                return $channel->playlist->dvrSetting;
+            }
+        }
+
+        return null;
+    }
+
     private function scheduleDvr(Request $request, $playlist, ?PlaylistAuth $playlistAuth): \Illuminate\Http\JsonResponse
     {
         $channelId = (int) $request->input('channel_id');
@@ -4388,7 +4403,15 @@ class XtreamApiController extends Controller
             return response()->json(['error' => 'channel_id, title, start_time, and end_time are required'], 400);
         }
 
-        $dvrSetting = $playlist->dvrSetting?->enabled ? $playlist->dvrSetting : null;
+        $channel = $playlist->channels()->where('channels.id', $channelId)->first();
+        if (! $channel) {
+            return response()->json(['error' => 'Channel not found'], 404);
+        }
+
+        // Resolve the DVR setting through the channel first so recordings
+        // scheduled via merged/custom playlists route to the real source
+        // playlist's DVR setting.
+        $dvrSetting = $this->resolveDvrSetting($playlist, $channelId);
 
         if (! $dvrSetting) {
             return response()->json(['error' => 'DVR is not enabled for this playlist'], 422);
@@ -4398,9 +4421,75 @@ class XtreamApiController extends Controller
             return response()->json(['error' => 'Concurrent recording limit reached'], 422);
         }
 
-        $channel = $playlist->channels()->where('channels.id', $channelId)->first();
-        if (! $channel) {
-            return response()->json(['error' => 'Channel not found'], 404);
+        if ($dvrSetting->isAtCapacity()) {
+            return response()->json(['error' => 'Concurrent recording limit reached'], 422);
+        }
+
+        // Provider-capacity check (e.g. an Antenna/HDHomeRun pool with a
+        // fixed tuner count): refuse at schedule time when the pool is full.
+        // Count recording rows PLUS still-running broadcasts (a broadcast can
+        // outlive its row's Recording status during stop drain) PLUS imminent
+        // scheduled recordings (starting within 10 minutes) so rapid-fire
+        // taps can't slip past before the previous ones start.
+        $sourceLimit = $channel->playlist instanceof Playlist ? $channel->playlist->available_streams : 0;
+        $effectiveLimit = 0;
+        if ($sourceLimit > 0) {
+            $effectiveLimit = $sourceLimit;
+        }
+        if ($playlist->available_streams > 0) {
+            $effectiveLimit = $effectiveLimit === 0
+                ? $playlist->available_streams
+                : min($effectiveLimit, $playlist->available_streams);
+        }
+        if ($effectiveLimit > 0) {
+            $activeDvrChannelIds = $dvrSetting->recordings()
+                ->where('status', DvrRecordingStatus::Recording)
+                ->pluck('channel_id')
+                ->map(fn ($c) => (int) $c)
+                ->unique()
+                ->values()
+                ->all();
+
+            $runningBroadcastChannelIds = [];
+            $runningDvrIds = app(M3uProxyService::class)->getRunningDvrRecordingIds();
+            if ($runningDvrIds !== []) {
+                $runningBroadcastChannelIds = $dvrSetting->recordings()
+                    ->whereIn('id', $runningDvrIds)
+                    ->pluck('channel_id')
+                    ->map(fn ($c) => (int) $c)
+                    ->unique()
+                    ->values()
+                    ->all();
+            }
+
+            $liveIds = M3uProxyService::getActiveLiveChannelIds($playlist->uuid);
+            if ($channel->playlist instanceof Playlist && $channel->playlist->uuid !== $playlist->uuid) {
+                $liveIds = array_merge($liveIds, M3uProxyService::getActiveLiveChannelIds($channel->playlist->uuid));
+            }
+
+            $activeChannelIds = array_values(array_unique(array_merge(
+                $activeDvrChannelIds,
+                $runningBroadcastChannelIds,
+                array_map('intval', $liveIds),
+            )));
+
+            $imminentScheduled = $dvrSetting->recordings()
+                ->where('status', DvrRecordingStatus::Scheduled)
+                ->where('scheduled_start', '<=', now()->addMinutes(10))
+                ->pluck('channel_id')
+                ->map(fn ($c) => (int) $c)
+                ->unique()
+                ->values()
+                ->all();
+
+            $projectedActiveChannelIds = array_values(array_unique(array_merge($activeChannelIds, $imminentScheduled)));
+
+            $willPiggyback = in_array((int) $channelId, $projectedActiveChannelIds, true);
+            $projected = count($projectedActiveChannelIds) + ($willPiggyback ? 0 : 1);
+
+            if ($projected > $effectiveLimit) {
+                return response()->json(['error' => 'Playlist has reached maximum stream limit.'], 422);
+            }
         }
 
         // manual_start/manual_end are cast as `datetime`, which Eloquent re-hydrates by

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -3980,9 +3980,9 @@ class XtreamApiController extends Controller
      */
     private function getDvrRecordings(Request $request, $playlist, string $username, string $password, ?PlaylistAuth $playlistAuth): \Illuminate\Http\JsonResponse
     {
-        $dvrSetting = $playlist->dvrSetting;
+        $dvrSettingIds = $this->resolveDvrSettingIds($playlist);
 
-        if (! $dvrSetting) {
+        if ($dvrSettingIds === []) {
             return response()->json([]);
         }
 
@@ -3990,7 +3990,7 @@ class XtreamApiController extends Controller
         $limit = min((int) $request->input('limit', 50), 200);
         $offset = (int) $request->input('offset', 0);
 
-        $query = DvrRecording::where('dvr_setting_id', $dvrSetting->id)
+        $query = DvrRecording::whereIn('dvr_setting_id', $dvrSettingIds)
             ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
             ->with(['channel', 'dvrSetting', 'recordingRule'])
             ->orderByDesc('scheduled_start');
@@ -4018,13 +4018,13 @@ class XtreamApiController extends Controller
             return response()->json(['error' => 'recording_id parameter is required'], 400);
         }
 
-        $dvrSetting = $playlist->dvrSetting;
+        $dvrSettingIds = $this->resolveDvrSettingIds($playlist);
 
-        if (! $dvrSetting) {
+        if ($dvrSettingIds === []) {
             return response()->json(['error' => 'DVR not configured for this playlist'], 404);
         }
 
-        $recording = DvrRecording::where('dvr_setting_id', $dvrSetting->id)
+        $recording = DvrRecording::whereIn('dvr_setting_id', $dvrSettingIds)
             ->where('uuid', $uuid)
             ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
             ->with(['channel', 'dvrSetting', 'recordingRule'])
@@ -4390,6 +4390,37 @@ class XtreamApiController extends Controller
         }
 
         return null;
+    }
+
+    /**
+     * Resolve the DVR setting ids a playlist can see recordings for. For a
+     * real Playlist that's its own setting; for a MergedPlaylist it's the
+     * settings of all source playlists (recordings are always created on the
+     * source playlist's setting).
+     *
+     * @return array<int, int>
+     */
+    private function resolveDvrSettingIds($playlist): array
+    {
+        if ($playlist instanceof Playlist) {
+            return $playlist->dvrSetting ? [$playlist->dvrSetting->id] : [];
+        }
+
+        $sourcePlaylistIds = DB::table('merged_playlist_playlist')
+            ->where('merged_playlist_id', $playlist->id)
+            ->pluck('playlist_id');
+
+        $settingIds = \App\Models\DvrSetting::whereIn('playlist_id', $sourcePlaylistIds)
+            ->pluck('id')
+            ->toArray();
+
+        // Include the merged playlist's own setting too, in case recordings
+        // were ever created against it directly.
+        if ($playlist->dvrSetting) {
+            $settingIds[] = $playlist->dvrSetting->id;
+        }
+
+        return array_values(array_unique($settingIds));
     }
 
     private function scheduleDvr(Request $request, $playlist, ?PlaylistAuth $playlistAuth): \Illuminate\Http\JsonResponse
@@ -4758,13 +4789,13 @@ class XtreamApiController extends Controller
             return response()->json(['error' => 'recording_id parameter is required'], 400);
         }
 
-        $dvrSetting = $playlist->dvrSetting;
+        $dvrSettingIds = $this->resolveDvrSettingIds($playlist);
 
-        if (! $dvrSetting) {
+        if ($dvrSettingIds === []) {
             return response()->json(['error' => 'DVR not configured for this playlist'], 404);
         }
 
-        $recording = DvrRecording::where('dvr_setting_id', $dvrSetting->id)
+        $recording = DvrRecording::whereIn('dvr_setting_id', $dvrSettingIds)
             ->where('uuid', $uuid)
             ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
             ->whereIn('status', [DvrRecordingStatus::Scheduled, DvrRecordingStatus::Recording])

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -4390,6 +4390,12 @@ class XtreamApiController extends Controller
             }
         }
 
+        // The requesting playlist's own setting (e.g. a MergedPlaylist with
+        // its own DvrSetting) as a fallback.
+        if ($playlist->dvrSetting?->enabled) {
+            return $playlist->dvrSetting;
+        }
+
         return null;
     }
 

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -18,6 +18,7 @@ use App\Models\Channel;
 use App\Models\CustomPlaylist;
 use App\Models\DvrRecording;
 use App\Models\DvrRecordingRule;
+use App\Models\DvrSetting;
 use App\Models\DynamicGroup;
 use App\Models\EmbyLibraryMapping;
 use App\Models\Epg;
@@ -4377,7 +4378,7 @@ class XtreamApiController extends Controller
     /**
      * Schedule a one-shot DVR recording rule from the TV app.
      */
-    private function resolveDvrSetting($playlist, ?int $channelId = null): ?\App\Models\DvrSetting
+    private function resolveDvrSetting($playlist, ?int $channelId = null): ?DvrSetting
     {
         if ($playlist instanceof Playlist && $playlist->dvrSetting?->enabled) {
             return $playlist->dvrSetting;
@@ -4410,7 +4411,7 @@ class XtreamApiController extends Controller
             ->where('merged_playlist_id', $playlist->id)
             ->pluck('playlist_id');
 
-        $settingIds = \App\Models\DvrSetting::whereIn('playlist_id', $sourcePlaylistIds)
+        $settingIds = DvrSetting::whereIn('playlist_id', $sourcePlaylistIds)
             ->pluck('id')
             ->toArray();
 

--- a/app/Jobs/StartDvrRecording.php
+++ b/app/Jobs/StartDvrRecording.php
@@ -23,6 +23,19 @@ class StartDvrRecording implements ShouldBeUnique, ShouldQueue
 {
     use Queueable;
 
+    /**
+     * How many total start attempts are allowed before the recording fails.
+     * Transient provider failures (an HDHomeRun tuner momentarily busy, a
+     * pooled provider connection settling) can clear within seconds — a
+     * recording that succeeds on attempt 2 or 3 is still a win.
+     */
+    public const int MAX_START_ATTEMPTS = 3;
+
+    /**
+     * Delay between retry attempts.
+     */
+    public const int RETRY_DELAY_SECONDS = 15;
+
     public int $tries = 1;
 
     public int $timeout = 30;
@@ -61,11 +74,37 @@ class StartDvrRecording implements ShouldBeUnique, ShouldQueue
         try {
             $recorder->start($recording);
         } catch (Throwable $e) {
+            // Transient provider failures (e.g. an HDHomeRun tuner momentarily
+            // busy with a lingering session or another client) can clear
+            // within seconds. Retry a bounded number of times while the
+            // programme is still on air instead of failing the recording
+            // outright.
+            $attempt = ($recording->attempt_count ?? 0) + 1;
+            $stillOnAir = $recording->scheduled_end && $recording->scheduled_end->isAfter(now());
+
+            if ($attempt < self::MAX_START_ATTEMPTS && $stillOnAir) {
+                $recording->update([
+                    'attempt_count' => $attempt,
+                ]);
+
+                Log::warning('StartDvrRecording: attempt '.$attempt.' failed — retrying in '.self::RETRY_DELAY_SECONDS.'s', [
+                    'recording_id' => $this->recordingId,
+                    'error' => $e->getMessage(),
+                ]);
+
+                self::dispatch($recording->id)
+                    ->onQueue('dvr')
+                    ->delay(now()->addSeconds(self::RETRY_DELAY_SECONDS));
+
+                return;
+            }
+
             Log::error("StartDvrRecording: recording {$this->recordingId} failed to start — {$e->getMessage()}");
 
             $recording->update([
                 'status' => DvrRecordingStatus::Failed->value,
                 'error_message' => $e->getMessage(),
+                'attempt_count' => $attempt,
             ]);
 
             $recording->notifyTv(__('Recording Failed'), 'danger');

--- a/app/Models/DvrRecording.php
+++ b/app/Models/DvrRecording.php
@@ -329,7 +329,12 @@ class DvrRecording extends Model
      */
     public function notifyTv(string $title, string $status): void
     {
-        $playlist = $this->dvrSetting?->owner();
+        // Guest-created recordings (playlistAuth) notify the playlist the
+        // guest authenticated through — for merged credentials that is the
+        // MergedPlaylist the app's notification scope queries, NOT the DVR
+        // setting's owner (the source playlist), which the app never sees.
+        $playlist = $this->playlistAuth?->playlist()
+            ?? $this->dvrSetting?->owner();
 
         if (! $playlist) {
             return;

--- a/app/Models/DvrSetting.php
+++ b/app/Models/DvrSetting.php
@@ -100,8 +100,12 @@ class DvrSetting extends Model
      */
     public function isAtCapacity(int $pendingInTick = 0): bool
     {
+        // Count only in-progress recordings. PostProcessing recordings have
+        // finished capturing — counting them blocks new recordings during the
+        // entire post-processing window even though the tuner/connection is
+        // already free.
         $active = $this->recordings()
-            ->whereIn('status', [DvrRecordingStatus::Recording, DvrRecordingStatus::PostProcessing])
+            ->where('status', DvrRecordingStatus::Recording)
             ->count();
 
         return ($active + $pendingInTick) >= $this->max_concurrent_recordings;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -355,6 +355,20 @@ class AppServiceProvider extends ServiceProvider
             return Limit::perMinute(60)->by(optional($request->user())->id ?: $request->ip());
         });
 
+        // TV app API routes (api/tv/...) are consumed exclusively by the TV
+        // frontend, which legitimately polls notifications on boot, resume,
+        // and live-stream end (plus mark-read + push + broadcast-auth calls).
+        // A per-IP limit shares one counter across every device on a LAN and
+        // trips on that polling; key by the URL credentials instead so each
+        // TV install gets generous headroom while brute-forcing credentials
+        // is still throttled per attempt.
+        RateLimiter::for('tv-api', function (Request $request) {
+            $segments = $request->segments();
+            $credentialKey = ($segments[2] ?? '').'|'.($segments[3] ?? '');
+
+            return Limit::perMinute(240)->by($credentialKey);
+        });
+
         // Note: Proxy rate limiting is handled by ProxyRateLimitMiddleware for better performance
 
         // Gate the copilot stream endpoint behind the use_ai_copilot permission.

--- a/app/Services/DvrRecorderService.php
+++ b/app/Services/DvrRecorderService.php
@@ -64,7 +64,8 @@ class DvrRecorderService
                 'proxy_network_id' => null,
             ]);
 
-            $playlist = $recording->dvrSetting?->owner();
+            $playlist = $recording->playlistAuth?->playlist()
+                ?? $recording->dvrSetting?->owner();
             if ($playlist) {
                 $playlistKey = $playlist->getMorphClass().':'.$playlist->id;
                 $byPlaylist[$playlistKey] ??= ['playlist' => $playlist, 'count' => 0];
@@ -331,18 +332,19 @@ class DvrRecorderService
             'playlist_auth_id' => $playlistAuthId,
         ]);
 
-        if (! $playlistUuid) {
-            return;
-        }
-
-        $playlist = Playlist::where('uuid', $playlistUuid)->first();
-        if (! $playlist) {
-            return;
-        }
-
+        // Target the notifiable the evicted viewer's app actually queries: the
+        // playlist the viewer authenticated through (for merged credentials,
+        // the MergedPlaylist — the source playlist would be invisible to the
+        // viewer's notification scope).
         $playlistAuth = $playlistAuthId
             ? PlaylistAuth::find($playlistAuthId)
             : null;
+
+        $playlist = $playlistAuth?->playlist()
+            ?? ($playlistUuid ? Playlist::where('uuid', $playlistUuid)->first() : null);
+        if (! $playlist) {
+            return;
+        }
 
         AppNotification::make()
             ->title(__('DVR Recording Started'))

--- a/app/Services/DvrRecorderService.php
+++ b/app/Services/DvrRecorderService.php
@@ -94,7 +94,7 @@ class DvrRecorderService
      * The proxy manages the FFmpeg process, preserves all HLS segments (dvr_mode=true),
      * and calls back the editor when the recording ends or fails.
      */
-    public function start(DvrRecording $recording): void
+    public function start(DvrRecording $recording, bool $forceFresh = false): void
     {
         if ($recording->status !== DvrRecordingStatus::Scheduled) {
             Log::warning('DVR start skipped - recording not in SCHEDULED state', [
@@ -182,8 +182,12 @@ class DvrRecorderService
         // Use the channel's own real source playlist (not the DvrSetting's owner,
         // which may be a Custom/Merged playlist spanning multiple real playlists)
         // since that's what the proxy actually keys active streams by.
+        //
+        // On a retry ($forceFresh) the previous attempt may have piggybacked
+        // onto a pooled stream whose upstream went stale — reuse would fail
+        // again, so resolve a fresh stream instead.
         $playlistUuid = $channel?->getEffectivePlaylist()?->uuid;
-        if ($channel && $playlistUuid) {
+        if (! $forceFresh && $channel && $playlistUuid) {
             $activeStreamId = $this->proxy->getActiveStreamIdForChannel($channel->id, $playlistUuid);
             if ($activeStreamId) {
                 $proxyUrl = $this->proxy->getStreamProxyUrl($activeStreamId);

--- a/app/Services/DvrRecorderService.php
+++ b/app/Services/DvrRecorderService.php
@@ -126,12 +126,52 @@ class DvrRecorderService
             // recording is never lost to a transient proxy/provider error.
             $sourcePlaylist = $channel->playlist;
             if ($sourcePlaylist instanceof Playlist && $sourcePlaylist->profiles_enabled) {
-                // Snapshot the active live streams so we can detect which ones a
-                // "DVR wins" eviction stopped (getChannelUrl stops the oldest
-                // stream when the pool is full) and notify the affected viewers.
-                $streamsBefore = $this->proxy->getActiveLiveStreams($sourcePlaylist->uuid);
+// Snapshot the active live streams so we can detect which ones a
+            // "DVR wins" eviction stopped and notify the affected viewers.
+            $streamsBefore = $this->proxy->getActiveLiveStreams($sourcePlaylist->uuid);
 
-                try {
+            // Pre-evict the oldest LIVE-VIEWER stream (never a recording's
+            // stream) when the pool is full, so getChannelUrl's age-based
+            // stopOldestOnLimit cannot kill an active recording's stream.
+            $totalProfileSlots = 0;
+            foreach ($sourcePlaylist->profiles()->where('enabled', true)->get() as $profile) {
+                $totalProfileSlots += (int) $profile->effective_max_streams;
+            }
+
+            if ($totalProfileSlots > 0 && count($streamsBefore) >= $totalProfileSlots) {
+                $recordingChannelIds = $setting->recordings()
+                    ->where('status', DvrRecordingStatus::Recording)
+                    ->pluck('channel_id')
+                    ->map(fn ($c) => (int) $c)
+                    ->all();
+
+                // Oldest first — a viewer whose stream is evicted should be
+                // the one who has been watching the longest.
+                usort($streamsBefore, fn ($a, $b) => strcmp((string) ($a['created_at'] ?? ''), (string) ($b['created_at'] ?? '')));
+
+                $preEvictedStreamId = null;
+                foreach ($streamsBefore as $candidate) {
+                    $streamChannelId = (int) ($candidate['metadata']['channel_id'] ?? 0);
+                    if (in_array($streamChannelId, $recordingChannelIds, true)) {
+                        continue;
+                    }
+
+                    if ($this->proxy->deleteStream($candidate['stream_id'])) {
+                        $preEvictedStreamId = $candidate['stream_id'];
+                        Log::info('DVR: evicted oldest live stream for recording', [
+                            'recording_id' => $recording->id,
+                            'title' => $recording->title,
+                            'evicted_stream_id' => $candidate['stream_id'],
+                            'evicted_channel_id' => $streamChannelId,
+                        ]);
+                        $this->notifyEvictedViewer($candidate, $recording);
+                        usleep(200000); // 200ms for the proxy to release the slot
+                    }
+                    break;
+                }
+            }
+
+            try {
                     $streamUrl = $this->proxy->getChannelUrl(
                         $sourcePlaylist,
                         $channel,
@@ -157,9 +197,13 @@ class DvrRecorderService
                 }
 
                 // Notify the viewers of any live stream the DVR-wins eviction
-                // stopped while resolving this recording's URL.
+                // stopped while resolving this recording's URL (the pre-evicted
+                // stream was already notified above — skip it here).
                 $streamsAfter = $this->proxy->getActiveLiveStreams($sourcePlaylist->uuid);
                 foreach ($streamsBefore as $before) {
+                    if (isset($preEvictedStreamId) && ($before['stream_id'] ?? null) === $preEvictedStreamId) {
+                        continue;
+                    }
                     $stillActive = collect($streamsAfter)->first(
                         fn ($after) => ($after['stream_id'] ?? null) === ($before['stream_id'] ?? null),
                     );

--- a/app/Services/DvrRecorderService.php
+++ b/app/Services/DvrRecorderService.php
@@ -125,10 +125,18 @@ class DvrRecorderService
             // viewer does. Fall back to the raw channel URL if resolution fails so a
             // recording is never lost to a transient proxy/provider error.
             $sourcePlaylist = $channel->playlist;
-            if ($sourcePlaylist instanceof Playlist && $sourcePlaylist->profiles_enabled) {
+            if ($sourcePlaylist instanceof Playlist && ($sourcePlaylist->profiles_enabled || $sourcePlaylist->enable_proxy)) {
 // Snapshot the active live streams so we can detect which ones a
             // "DVR wins" eviction stopped and notify the affected viewers.
-            $streamsBefore = $this->proxy->getActiveLiveStreams($sourcePlaylist->uuid);
+            // Live streams created via a merged/custom wrapper carry the
+            // WRAPPER's playlist_uuid (recordings' streams carry the source
+            // uuid), so match on original_playlist_uuid — upstream keys pool
+            // lookups on the source uuid, and both variants set it.
+            $allStreams = $this->proxy->getActiveLiveStreams();
+            $streamsBefore = array_values(array_filter(
+                $allStreams,
+                fn ($s) => ($s['metadata']['original_playlist_uuid'] ?? $s['metadata']['playlist_uuid'] ?? null) === $sourcePlaylist->uuid,
+            ));
 
             // Pre-evict the oldest LIVE-VIEWER stream (never a recording's
             // stream) when the pool is full, so getChannelUrl's age-based
@@ -144,6 +152,17 @@ class DvrRecorderService
                     ->pluck('channel_id')
                     ->map(fn ($c) => (int) $c)
                     ->all();
+
+                Log::info('DVR: pool full, evaluating pre-eviction', [
+                    'recording_id' => $recording->id,
+                    'streams' => array_map(fn ($s) => [
+                        'id' => substr($s['stream_id'], 0, 8),
+                        'channel_id' => $s['metadata']['channel_id'] ?? null,
+                        'created' => $s['created_at'],
+                    ], $streamsBefore),
+                    'recording_channel_ids' => $recordingChannelIds,
+                    'total_slots' => $totalProfileSlots,
+                ]);
 
                 // Oldest first — a viewer whose stream is evicted should be
                 // the one who has been watching the longest.
@@ -199,7 +218,11 @@ class DvrRecorderService
                 // Notify the viewers of any live stream the DVR-wins eviction
                 // stopped while resolving this recording's URL (the pre-evicted
                 // stream was already notified above — skip it here).
-                $streamsAfter = $this->proxy->getActiveLiveStreams($sourcePlaylist->uuid);
+                $allStreamsAfter = $this->proxy->getActiveLiveStreams();
+                $streamsAfter = array_values(array_filter(
+                    $allStreamsAfter,
+                    fn ($s) => ($s['metadata']['original_playlist_uuid'] ?? $s['metadata']['playlist_uuid'] ?? null) === $sourcePlaylist->uuid,
+                ));
                 foreach ($streamsBefore as $before) {
                     if (isset($preEvictedStreamId) && ($before['stream_id'] ?? null) === $preEvictedStreamId) {
                         continue;
@@ -292,7 +315,10 @@ class DvrRecorderService
     protected function notifyEvictedViewer(array $stream, DvrRecording $recording): void
     {
         $metadata = $stream['metadata'] ?? [];
-        $playlistUuid = $metadata['playlist_uuid'] ?? null;
+        // Live streams created via a merged/custom wrapper carry the WRAPPER's
+        // uuid in playlist_uuid (a MergedPlaylist/CustomPlaylist, not a
+        // Playlist). original_playlist_uuid is always the real Playlist uuid.
+        $playlistUuid = $metadata['original_playlist_uuid'] ?? $metadata['playlist_uuid'] ?? null;
         $playlistAuthId = isset($metadata['playlist_auth_id'])
             ? (int) $metadata['playlist_auth_id']
             : null;

--- a/app/Services/DvrRecorderService.php
+++ b/app/Services/DvrRecorderService.php
@@ -127,71 +127,71 @@ class DvrRecorderService
             // recording is never lost to a transient proxy/provider error.
             $sourcePlaylist = $channel->playlist;
             if ($sourcePlaylist instanceof Playlist && ($sourcePlaylist->profiles_enabled || $sourcePlaylist->enable_proxy)) {
-// Snapshot the active live streams so we can detect which ones a
-            // "DVR wins" eviction stopped and notify the affected viewers.
-            // Live streams created via a merged/custom wrapper carry the
-            // WRAPPER's playlist_uuid (recordings' streams carry the source
-            // uuid), so match on original_playlist_uuid — upstream keys pool
-            // lookups on the source uuid, and both variants set it.
-            $allStreams = $this->proxy->getActiveLiveStreams();
-            $streamsBefore = array_values(array_filter(
-                $allStreams,
-                fn ($s) => ($s['metadata']['original_playlist_uuid'] ?? $s['metadata']['playlist_uuid'] ?? null) === $sourcePlaylist->uuid,
-            ));
+                // Snapshot the active live streams so we can detect which ones a
+                // "DVR wins" eviction stopped and notify the affected viewers.
+                // Live streams created via a merged/custom wrapper carry the
+                // WRAPPER's playlist_uuid (recordings' streams carry the source
+                // uuid), so match on original_playlist_uuid — upstream keys pool
+                // lookups on the source uuid, and both variants set it.
+                $allStreams = $this->proxy->getActiveLiveStreams();
+                $streamsBefore = array_values(array_filter(
+                    $allStreams,
+                    fn ($s) => ($s['metadata']['original_playlist_uuid'] ?? $s['metadata']['playlist_uuid'] ?? null) === $sourcePlaylist->uuid,
+                ));
 
-            // Pre-evict the oldest LIVE-VIEWER stream (never a recording's
-            // stream) when the pool is full, so getChannelUrl's age-based
-            // stopOldestOnLimit cannot kill an active recording's stream.
-            $totalProfileSlots = 0;
-            foreach ($sourcePlaylist->profiles()->where('enabled', true)->get() as $profile) {
-                $totalProfileSlots += (int) $profile->effective_max_streams;
-            }
-
-            if ($totalProfileSlots > 0 && count($streamsBefore) >= $totalProfileSlots) {
-                $recordingChannelIds = $setting->recordings()
-                    ->where('status', DvrRecordingStatus::Recording)
-                    ->pluck('channel_id')
-                    ->map(fn ($c) => (int) $c)
-                    ->all();
-
-                Log::info('DVR: pool full, evaluating pre-eviction', [
-                    'recording_id' => $recording->id,
-                    'streams' => array_map(fn ($s) => [
-                        'id' => substr($s['stream_id'], 0, 8),
-                        'channel_id' => $s['metadata']['channel_id'] ?? null,
-                        'created' => $s['created_at'],
-                    ], $streamsBefore),
-                    'recording_channel_ids' => $recordingChannelIds,
-                    'total_slots' => $totalProfileSlots,
-                ]);
-
-                // Oldest first — a viewer whose stream is evicted should be
-                // the one who has been watching the longest.
-                usort($streamsBefore, fn ($a, $b) => strcmp((string) ($a['created_at'] ?? ''), (string) ($b['created_at'] ?? '')));
-
-                $preEvictedStreamId = null;
-                foreach ($streamsBefore as $candidate) {
-                    $streamChannelId = (int) ($candidate['metadata']['channel_id'] ?? 0);
-                    if (in_array($streamChannelId, $recordingChannelIds, true)) {
-                        continue;
-                    }
-
-                    if ($this->proxy->deleteStream($candidate['stream_id'])) {
-                        $preEvictedStreamId = $candidate['stream_id'];
-                        Log::info('DVR: evicted oldest live stream for recording', [
-                            'recording_id' => $recording->id,
-                            'title' => $recording->title,
-                            'evicted_stream_id' => $candidate['stream_id'],
-                            'evicted_channel_id' => $streamChannelId,
-                        ]);
-                        $this->notifyEvictedViewer($candidate, $recording);
-                        usleep(200000); // 200ms for the proxy to release the slot
-                    }
-                    break;
+                // Pre-evict the oldest LIVE-VIEWER stream (never a recording's
+                // stream) when the pool is full, so getChannelUrl's age-based
+                // stopOldestOnLimit cannot kill an active recording's stream.
+                $totalProfileSlots = 0;
+                foreach ($sourcePlaylist->profiles()->where('enabled', true)->get() as $profile) {
+                    $totalProfileSlots += (int) $profile->effective_max_streams;
                 }
-            }
 
-            try {
+                if ($totalProfileSlots > 0 && count($streamsBefore) >= $totalProfileSlots) {
+                    $recordingChannelIds = $setting->recordings()
+                        ->where('status', DvrRecordingStatus::Recording)
+                        ->pluck('channel_id')
+                        ->map(fn ($c) => (int) $c)
+                        ->all();
+
+                    Log::info('DVR: pool full, evaluating pre-eviction', [
+                        'recording_id' => $recording->id,
+                        'streams' => array_map(fn ($s) => [
+                            'id' => substr($s['stream_id'], 0, 8),
+                            'channel_id' => $s['metadata']['channel_id'] ?? null,
+                            'created' => $s['created_at'],
+                        ], $streamsBefore),
+                        'recording_channel_ids' => $recordingChannelIds,
+                        'total_slots' => $totalProfileSlots,
+                    ]);
+
+                    // Oldest first — a viewer whose stream is evicted should be
+                    // the one who has been watching the longest.
+                    usort($streamsBefore, fn ($a, $b) => strcmp((string) ($a['created_at'] ?? ''), (string) ($b['created_at'] ?? '')));
+
+                    $preEvictedStreamId = null;
+                    foreach ($streamsBefore as $candidate) {
+                        $streamChannelId = (int) ($candidate['metadata']['channel_id'] ?? 0);
+                        if (in_array($streamChannelId, $recordingChannelIds, true)) {
+                            continue;
+                        }
+
+                        if ($this->proxy->deleteStream($candidate['stream_id'])) {
+                            $preEvictedStreamId = $candidate['stream_id'];
+                            Log::info('DVR: evicted oldest live stream for recording', [
+                                'recording_id' => $recording->id,
+                                'title' => $recording->title,
+                                'evicted_stream_id' => $candidate['stream_id'],
+                                'evicted_channel_id' => $streamChannelId,
+                            ]);
+                            $this->notifyEvictedViewer($candidate, $recording);
+                            usleep(200000); // 200ms for the proxy to release the slot
+                        }
+                        break;
+                    }
+                }
+
+                try {
                     $streamUrl = $this->proxy->getChannelUrl(
                         $sourcePlaylist,
                         $channel,

--- a/app/Services/DvrRecorderService.php
+++ b/app/Services/DvrRecorderService.php
@@ -10,6 +10,7 @@ use App\Models\CustomPlaylist;
 use App\Models\DvrRecording;
 use App\Models\MergedPlaylist;
 use App\Models\Playlist;
+use App\Models\PlaylistAuth;
 use App\Models\TvNotification;
 use App\Notifications\Notification as AppNotification;
 use Exception;
@@ -125,6 +126,11 @@ class DvrRecorderService
             // recording is never lost to a transient proxy/provider error.
             $sourcePlaylist = $channel->playlist;
             if ($sourcePlaylist instanceof Playlist && $sourcePlaylist->profiles_enabled) {
+                // Snapshot the active live streams so we can detect which ones a
+                // "DVR wins" eviction stopped (getChannelUrl stops the oldest
+                // stream when the pool is full) and notify the affected viewers.
+                $streamsBefore = $this->proxy->getActiveLiveStreams($sourcePlaylist->uuid);
+
                 try {
                     $streamUrl = $this->proxy->getChannelUrl(
                         $sourcePlaylist,
@@ -137,28 +143,29 @@ class DvrRecorderService
                         $streamUrl = $rawUrl;
                     }
                 } catch (\Throwable $e) {
-                    // UNRESOLVED - behavior still being decided.
-                    //
                     // getChannelUrl() aborts (503) when every provider profile is at
-                    // capacity. Right now we swallow that and fall back to the raw
-                    // primary-account URL so the recording is never lost, relying on the
-                    // fact that most providers boot an older stream when a new one starts,
-                    // so DVR effectively wins.
-                    //
-                    // The counter-argument: the whole point of pooled profiles is to
-                    // manage the connection budget explicitly and reject at the limit.
-                    // Silently exceeding it here undermines that. The alternative is to
-                    // rethrow (or only catch genuinely transient errors) and let a
-                    // capacity-blocked recording fail loudly.
-                    //
-                    // TODO: decide between "DVR always wins (current)" vs "respect the
-                    // pool limit and fail the recording". Revisit once real-world pooled
-                    // DVR usage tells us which matters more.
+                    // capacity. "DVR wins": swallow that and fall back to the raw
+                    // primary-account URL so the recording is never lost, relying on
+                    // the fact that most providers boot an older stream when a new
+                    // one starts. (When proxy_stop_oldest_on_limit is enabled,
+                    // getChannelUrl evicts the oldest live stream instead.)
                     Log::warning('DVR: pooled-provider URL resolution failed, using raw channel URL', [
                         'recording_id' => $recording->id,
                         'exception' => $e->getMessage(),
                     ]);
                     $streamUrl = $rawUrl;
+                }
+
+                // Notify the viewers of any live stream the DVR-wins eviction
+                // stopped while resolving this recording's URL.
+                $streamsAfter = $this->proxy->getActiveLiveStreams($sourcePlaylist->uuid);
+                foreach ($streamsBefore as $before) {
+                    $stillActive = collect($streamsAfter)->first(
+                        fn ($after) => ($after['stream_id'] ?? null) === ($before['stream_id'] ?? null),
+                    );
+                    if ($stillActive === null) {
+                        $this->notifyEvictedViewer($before, $recording);
+                    }
                 }
             } else {
                 $streamUrl = $rawUrl;
@@ -225,6 +232,49 @@ class DvrRecorderService
         }
 
         $recording->notifyTv(__('Recording Started'), 'info');
+    }
+
+    /**
+     * Notify the viewer whose live stream was evicted to make room for a DVR
+     * recording ("DVR wins" policy). Uses the stream metadata to target the
+     * owning playlist auth's devices specifically.
+     *
+     * @param  array{stream_id: string, metadata: array}  $stream
+     */
+    protected function notifyEvictedViewer(array $stream, DvrRecording $recording): void
+    {
+        $metadata = $stream['metadata'] ?? [];
+        $playlistUuid = $metadata['playlist_uuid'] ?? null;
+        $playlistAuthId = isset($metadata['playlist_auth_id'])
+            ? (int) $metadata['playlist_auth_id']
+            : null;
+
+        Log::info('DVR: live stream evicted for recording', [
+            'recording_id' => $recording->id,
+            'title' => $recording->title,
+            'evicted_stream_id' => $stream['stream_id'],
+            'playlist_uuid' => $playlistUuid,
+            'playlist_auth_id' => $playlistAuthId,
+        ]);
+
+        if (! $playlistUuid) {
+            return;
+        }
+
+        $playlist = Playlist::where('uuid', $playlistUuid)->first();
+        if (! $playlist) {
+            return;
+        }
+
+        $playlistAuth = $playlistAuthId
+            ? PlaylistAuth::find($playlistAuthId)
+            : null;
+
+        AppNotification::make()
+            ->title(__('DVR Recording Started'))
+            ->body(__('A DVR recording has taken precedence and stopped your live stream.'))
+            ->status('warning')
+            ->tvBroadcast($playlist, 'dvr', false, $playlistAuth);
     }
 
     /**

--- a/app/Services/DvrSchedulerService.php
+++ b/app/Services/DvrSchedulerService.php
@@ -11,6 +11,7 @@ use App\Jobs\StartDvrRecording;
 use App\Jobs\StopDvrRecording;
 use App\Models\Channel;
 use App\Models\DvrRecording;
+use App\Services\M3uProxyService;
 use App\Models\DvrRecordingRule;
 use App\Models\DvrSetting;
 use App\Models\EpgChannel;
@@ -66,10 +67,47 @@ class DvrSchedulerService
             // Minute-level precision for trigger and stop.
             $this->triggerPendingRecordings();
             $this->stopExpiredRecordings();
+            $this->reconcileStaleRecordings();
         } catch (Exception $e) {
             Log::error('DVR scheduler tick failed: '.$e->getMessage(), [
                 'exception' => $e,
             ]);
+        }
+    }
+
+    /**
+     * Mark RECORDING rows whose proxy broadcast is no longer running as
+     * FAILED. The proxy's broadcast_failed callback can be lost (network
+     * blip, restart) — without this a dead broadcast leaves a stale
+     * "recording" row that consumes a DVR capacity slot and shows up as
+     * recording in the apps. Broadcasts younger than RECONCILE_GRACE_SECONDS
+     * are left alone so a just-started recording has time to appear.
+     */
+    public function reconcileStaleRecordings(): void
+    {
+        $grace = 90;
+
+        $runningIds = app(M3uProxyService::class)->getRunningDvrRecordingIds();
+
+        $stale = DvrRecording::where('status', DvrRecordingStatus::Recording)
+            ->where('actual_start', '<=', now()->subSeconds($grace))
+            ->get()
+            ->reject(fn (DvrRecording $r) => $r->proxy_network_id && in_array($r->id, $runningIds, true));
+
+        foreach ($stale as $recording) {
+            Log::warning('DVR: reconciling stale recording (broadcast no longer running)', [
+                'recording_id' => $recording->id,
+                'title' => $recording->title,
+                'proxy_network_id' => $recording->proxy_network_id,
+            ]);
+
+            $recording->update([
+                'status' => DvrRecordingStatus::Failed->value,
+                'actual_end' => now(),
+                'error_message' => 'Broadcast is no longer running (failure callback was lost).',
+            ]);
+
+            $recording->notifyTv(__('Recording Failed'), 'danger');
         }
     }
 

--- a/app/Services/DvrSchedulerService.php
+++ b/app/Services/DvrSchedulerService.php
@@ -11,7 +11,6 @@ use App\Jobs\StartDvrRecording;
 use App\Jobs\StopDvrRecording;
 use App\Models\Channel;
 use App\Models\DvrRecording;
-use App\Services\M3uProxyService;
 use App\Models\DvrRecordingRule;
 use App\Models\DvrSetting;
 use App\Models\EpgChannel;

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -3751,7 +3751,7 @@ class M3uProxyService
      * UUID), including their metadata. Used to detect which streams a
      * DVR-wins eviction stopped so the affected viewer can be notified.
      *
-     * @return array<int, array{stream_id: string, metadata: array}>
+     * @return array<int, array{stream_id: string, created_at: ?string, metadata: array}>
      */
     public function getActiveLiveStreams(?string $playlistUuid = null): array
     {
@@ -3778,6 +3778,7 @@ class M3uProxyService
                 }
                 $result[] = [
                     'stream_id' => (string) ($stream['stream_id'] ?? ''),
+                    'created_at' => $stream['created_at'] ?? null,
                     'metadata' => $metadata,
                 ];
             }
@@ -3789,6 +3790,39 @@ class M3uProxyService
             ]);
 
             return [];
+        }
+    }
+
+    /**
+     * Delete a stream on the proxy (used to evict a specific live stream to
+     * make room for a DVR recording — never a recording-backed stream).
+     */
+    public function deleteStream(string $streamId): bool
+    {
+        if (empty($this->apiBaseUrl)) {
+            return false;
+        }
+
+        try {
+            $endpoint = $this->apiBaseUrl.'/streams/'.rawurlencode($streamId);
+            $response = Http::timeout(10)
+                ->acceptJson()
+                ->withHeaders($this->apiToken ? ['X-API-Token' => $this->apiToken] : [])
+                ->delete($endpoint);
+
+            if ($response->successful()) {
+                Log::debug("Stream {$streamId} deleted on proxy");
+
+                return true;
+            }
+
+            Log::warning("Failed to delete stream {$streamId} on proxy: HTTP {$response->status()}");
+
+            return false;
+        } catch (Exception $e) {
+            Log::warning("Could not delete stream {$streamId} on proxy: {$e->getMessage()}");
+
+            return false;
         }
     }
 

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -359,6 +359,51 @@ class M3uProxyService
      * Get active streams count by any metadata field/value combination.
      * Returns the number of distinct upstream connections (streams), not proxy client count.
      */
+    /**
+     * Get the DISTINCT channel ids currently being watched live on the given
+     * playlist UUID (proxy streams keyed by playlist_uuid metadata). Used by
+     * DVR capacity accounting so live viewers and recordings share the pool.
+     *
+     * @return array<int, int>
+     */
+    public static function getActiveLiveChannelIds(string $playlistUuid): array
+    {
+        $service = new self;
+
+        if (empty($service->apiBaseUrl)) {
+            return [];
+        }
+
+        try {
+            $response = Http::timeout(5)->acceptJson()
+                ->withHeaders($service->apiToken ? ['X-API-Token' => $service->apiToken] : [])
+                ->get($service->apiBaseUrl.'/streams/by-metadata', [
+                    'field' => 'playlist_uuid',
+                    'value' => $playlistUuid,
+                    'active_only' => true,
+                ]);
+
+            if (! $response->successful()) {
+                return [];
+            }
+
+            $ids = [];
+            foreach ($response->json()['matching_streams'] ?? [] as $stream) {
+                $metadata = $stream['metadata'] ?? [];
+                $channelId = $metadata['original_channel_id'] ?? $metadata['channel_id'] ?? null;
+                if ($channelId !== null) {
+                    $ids[(int) $channelId] = true;
+                }
+            }
+
+            return array_keys($ids);
+        } catch (Exception $e) {
+            Log::warning('Error listing active live channels: '.$e->getMessage());
+
+            return [];
+        }
+    }
+
     public static function getActiveStreamsCountByMetadata(string $field, string $value): int
     {
         $service = new self;
@@ -3656,6 +3701,95 @@ class M3uProxyService
     public function getDvrBroadcastLiveUrl(string $networkId): string
     {
         return $this->getPublicUrl().'/broadcast/'.rawurlencode($networkId).'/live.m3u8';
+    }
+
+    /**
+     * Get the recording DB ids of all RUNNING DVR broadcasts on the proxy.
+     *
+     * Used as ground truth for capacity accounting: a broadcast may keep
+     * running after its DB row already flipped to post_processing (e.g. a
+     * stop that hasn't fully drained FFmpeg yet), so counting rows alone
+     * under-reports occupied provider slots.
+     */
+    public function getRunningDvrRecordingIds(): array
+    {
+        if (empty($this->apiBaseUrl)) {
+            return [];
+        }
+
+        try {
+            $endpoint = $this->apiBaseUrl.'/broadcast';
+            $response = Http::timeout(10)
+                ->acceptJson()
+                ->withHeaders($this->apiToken ? ['X-API-Token' => $this->apiToken] : [])
+                ->get($endpoint);
+
+            if (! $response->successful()) {
+                return [];
+            }
+
+            $ids = [];
+            foreach (($response->json('broadcasts') ?? []) as $broadcast) {
+                if (($broadcast['status'] ?? null) === 'running'
+                    && ! empty($broadcast['metadata']['recording_db_id'])) {
+                    $ids[] = (int) $broadcast['metadata']['recording_db_id'];
+                }
+            }
+
+            return array_values(array_unique($ids));
+        } catch (Exception $e) {
+            Log::warning('Failed to list running DVR broadcasts', [
+                'exception' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
+    }
+
+    /**
+     * List active live streams on the proxy (optionally filtered by playlist
+     * UUID), including their metadata. Used to detect which streams a
+     * DVR-wins eviction stopped so the affected viewer can be notified.
+     *
+     * @return array<int, array{stream_id: string, metadata: array}>
+     */
+    public function getActiveLiveStreams(?string $playlistUuid = null): array
+    {
+        if (empty($this->apiBaseUrl)) {
+            return [];
+        }
+
+        try {
+            $endpoint = $this->apiBaseUrl.'/streams';
+            $response = Http::timeout(10)
+                ->acceptJson()
+                ->withHeaders($this->apiToken ? ['X-API-Token' => $this->apiToken] : [])
+                ->get($endpoint, ['active_only' => true]);
+
+            if (! $response->successful()) {
+                return [];
+            }
+
+            $result = [];
+            foreach (($response->json('streams') ?? []) as $stream) {
+                $metadata = $stream['metadata'] ?? [];
+                if ($playlistUuid !== null && ($metadata['playlist_uuid'] ?? null) !== $playlistUuid) {
+                    continue;
+                }
+                $result[] = [
+                    'stream_id' => (string) ($stream['stream_id'] ?? ''),
+                    'metadata' => $metadata,
+                ];
+            }
+
+            return $result;
+        } catch (Exception $e) {
+            Log::warning('Failed to list active live streams', [
+                'exception' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
     }
 
     /**

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -1186,28 +1186,52 @@ class M3uProxyService
         $primaryUrl = null;
         $actualChannel = $channel;  // Track the actual channel being used (may differ from original if failover)
 
-        if ($playlist->available_streams !== 0) {
-            $activeStreams = self::getActiveStreamsCountByMetadata('playlist_uuid', $playlist->uuid);
+        // The capacity authority is the SOURCE playlist (what streams key on) —
+        // a merged/custom wrapper may have available_streams=0 (unlimited)
+        // while its source has a hard limit (e.g. an HDHomeRun tuner pool).
+        $limitPlaylist = $channel->playlist instanceof Playlist
+            ? $channel->playlist
+            : $playlist;
+
+        if ($limitPlaylist->available_streams !== 0) {
+            // Count DISTINCT active channels: live proxy streams (which may be
+            // piggybacked by recordings) PLUS active DVR recordings. DVR
+            // recordings on direct-URL playlists (e.g. HDHomeRun tuners) never
+            // create a proxy stream, so counting streams alone lets a 5th live
+            // stream slip through while 4 recordings hold the tuners.
+            $liveIds = array_map('intval', self::getActiveLiveChannelIds($limitPlaylist->uuid));
+            $dvrChannelIds = [];
+            if ($limitPlaylist->dvrSetting) {
+                $dvrChannelIds = $limitPlaylist->dvrSetting->recordings()
+                    ->where('status', DvrRecordingStatus::Recording)
+                    ->pluck('channel_id')
+                    ->map(fn ($c) => (int) $c)
+                    ->all();
+            }
+            $activeChannelIds = array_values(array_unique(array_merge($liveIds, $dvrChannelIds)));
+            $activeStreams = count($activeChannelIds);
 
             // Keep track of original playlist in case we need to check failovers
             $originalUuid = $playlist->uuid;
 
-            if ($activeStreams >= $playlist->available_streams) {
+            if ($activeStreams >= $limitPlaylist->available_streams) {
                 // Check if "stop oldest on limit" is enabled in settings
                 if ($this->stopOldestOnLimit) {
                     // Stop the oldest stream to make room for the new one (latest wins)
-                    $stopResult = self::stopOldestPlaylistStream($playlist->uuid, $id);
+                    $stopResult = self::stopOldestPlaylistStream($limitPlaylist->uuid, $id);
 
                     if ($stopResult['deleted_count'] > 0) {
                         Log::debug('Stopped oldest stream to free capacity for new channel request', [
                             'channel_id' => $id,
-                            'playlist_uuid' => $playlist->uuid,
+                            'playlist_uuid' => $limitPlaylist->uuid,
                             'stream_age_seconds' => $stopResult['stream_age_seconds'] ?? null,
                         ]);
 
                         // Short delay to allow proxy to clean up
                         usleep(100000); // 100ms
-                        $activeStreams = self::getActiveStreamsCountByMetadata('playlist_uuid', $playlist->uuid);
+                        $liveIds = array_map('intval', self::getActiveLiveChannelIds($limitPlaylist->uuid));
+                        $activeChannelIds = array_values(array_unique(array_merge($liveIds, $dvrChannelIds)));
+                        $activeStreams = count($activeChannelIds);
                     }
                 }
 

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -1252,53 +1252,53 @@ class M3uProxyService
             // If still at capacity (either no live stream was evictable or the
             // eviction failed), check failovers
             if ($activeStreams >= $limitPlaylist->available_streams) {
-                    // Primary playlist is at capacity, check failovers
-                    $failoverChannels = $channel->failoverChannels()
-                        ->select([
-                            'channels.id',
-                            'channels.url',
-                            'channels.url_custom',
-                            'channels.playlist_id',
-                            'channels.custom_playlist_id',
-                        ])->get();
+                // Primary playlist is at capacity, check failovers
+                $failoverChannels = $channel->failoverChannels()
+                    ->select([
+                        'channels.id',
+                        'channels.url',
+                        'channels.url_custom',
+                        'channels.playlist_id',
+                        'channels.custom_playlist_id',
+                    ])->get();
 
-                    foreach ($failoverChannels as $failoverChannel) {
-                        $failoverPlaylist = $failoverChannel->getEffectivePlaylist();
+                foreach ($failoverChannels as $failoverChannel) {
+                    $failoverPlaylist = $failoverChannel->getEffectivePlaylist();
 
-                        // Check if failover playlist has limits and capacity
-                        if ($failoverPlaylist->available_streams === 0) {
-                            // No limits on this failover playlist, use it
+                    // Check if failover playlist has limits and capacity
+                    if ($failoverPlaylist->available_streams === 0) {
+                        // No limits on this failover playlist, use it
+                        $playlist = $failoverPlaylist;
+                        $actualChannel = $failoverChannel;  // Track that we're using a failover channel
+                        $primaryUrl = PlaylistUrlService::getChannelUrl($failoverChannel, $playlist);
+                        break;
+                    } else {
+                        // Check if failover playlist has capacity
+                        $failoverActiveStreams = self::getActiveStreamsCountByMetadata('playlist_uuid', $failoverPlaylist->uuid);
+
+                        if ($failoverActiveStreams < $failoverPlaylist->available_streams) {
+                            // Found available failover playlist
                             $playlist = $failoverPlaylist;
                             $actualChannel = $failoverChannel;  // Track that we're using a failover channel
                             $primaryUrl = PlaylistUrlService::getChannelUrl($failoverChannel, $playlist);
                             break;
-                        } else {
-                            // Check if failover playlist has capacity
-                            $failoverActiveStreams = self::getActiveStreamsCountByMetadata('playlist_uuid', $failoverPlaylist->uuid);
-
-                            if ($failoverActiveStreams < $failoverPlaylist->available_streams) {
-                                // Found available failover playlist
-                                $playlist = $failoverPlaylist;
-                                $actualChannel = $failoverChannel;  // Track that we're using a failover channel
-                                $primaryUrl = PlaylistUrlService::getChannelUrl($failoverChannel, $playlist);
-                                break;
-                            }
                         }
                     }
+                }
 
-                    // If we still have the original playlist, all are at capacity
-                    if ($playlist->uuid === $originalUuid) {
-                        Log::debug('Channel stream request denied - all playlists at capacity', [
-                            'channel_id' => $id,
-                            'primary_playlist' => $playlist->uuid,
-                            'primary_limit' => $playlist->available_streams,
-                            'primary_active' => $activeStreams,
-                        ]);
+                // If we still have the original playlist, all are at capacity
+                if ($playlist->uuid === $originalUuid) {
+                    Log::debug('Channel stream request denied - all playlists at capacity', [
+                        'channel_id' => $id,
+                        'primary_playlist' => $playlist->uuid,
+                        'primary_limit' => $playlist->available_streams,
+                        'primary_active' => $activeStreams,
+                    ]);
 
-                        abort(503, 'All playlists have reached their maximum stream limit. Please try again later.');
-                    }
+                    abort(503, 'All playlists have reached their maximum stream limit. Please try again later.');
                 }
             }
+        }
 
         // Per-PlaylistAuth stream limit check (only applies when proxy is in use)
         if ($playlistAuthId && ! $this->checkAndEnforceAuthStreamLimit($playlistAuthId, $id)) {

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -1215,28 +1215,43 @@ class M3uProxyService
             $originalUuid = $playlist->uuid;
 
             if ($activeStreams >= $limitPlaylist->available_streams) {
-                // Check if "stop oldest on limit" is enabled in settings
-                if ($this->stopOldestOnLimit) {
-                    // Stop the oldest stream to make room for the new one (latest wins)
-                    $stopResult = self::stopOldestPlaylistStream($limitPlaylist->uuid, $id);
+                // DVR-wins: recordings keep their slots unconditionally, so a
+                // LIVE request evicts the oldest LIVE-VIEWER stream (never a
+                // recording-backed one) instead of being refused — recording +
+                // playback share the pool exactly as two recordings do. Only a
+                // pool full of recordings (no live stream left to evict)
+                // refuses the request.
+                $liveCandidates = collect(self::getActiveLiveStreams())
+                    ->filter(fn (array $s) => ($s['metadata']['original_playlist_uuid'] ?? $s['metadata']['playlist_uuid'] ?? null) === $limitPlaylist->uuid)
+                    ->filter(fn (array $s) => (int) ($s['metadata']['channel_id'] ?? 0) !== (int) $id)
+                    ->filter(fn (array $s) => ! in_array((int) ($s['metadata']['channel_id'] ?? 0), $dvrChannelIds, true))
+                    ->sortBy(fn (array $s) => (string) ($s['created_at'] ?? ''))
+                    ->values();
 
-                    if ($stopResult['deleted_count'] > 0) {
-                        Log::debug('Stopped oldest stream to free capacity for new channel request', [
-                            'channel_id' => $id,
-                            'playlist_uuid' => $limitPlaylist->uuid,
-                            'stream_age_seconds' => $stopResult['stream_age_seconds'] ?? null,
-                        ]);
+                if ($liveCandidates->isNotEmpty()) {
+                    $oldest = $liveCandidates->first();
+                    self::deleteStream((string) $oldest['stream_id']);
 
-                        // Short delay to allow proxy to clean up
-                        usleep(100000); // 100ms
-                        $liveIds = array_map('intval', self::getActiveLiveChannelIds($limitPlaylist->uuid));
-                        $activeChannelIds = array_values(array_unique(array_merge($liveIds, $dvrChannelIds)));
-                        $activeStreams = count($activeChannelIds);
-                    }
+                    Log::debug('DVR-wins: stopped oldest live stream to free capacity for new channel request', [
+                        'channel_id' => $id,
+                        'playlist_uuid' => $limitPlaylist->uuid,
+                        'evicted_stream_id' => $oldest['stream_id'],
+                        'evicted_channel_id' => $oldest['metadata']['channel_id'] ?? null,
+                        'stream_created_at' => $oldest['created_at'] ?? null,
+                    ]);
+
+                    // A live slot was freed; the recording keeps its slot.
+                    // Recompute with live streams only — the new live request
+                    // may now proceed.
+                    usleep(100000); // 100ms to allow the proxy to clean up
+                    $liveIds = array_map('intval', self::getActiveLiveChannelIds($limitPlaylist->uuid));
+                    $activeStreams = count($liveIds);
                 }
+            }
 
-                // If still at capacity (either setting disabled or stop failed), check failovers
-                if ($activeStreams >= $playlist->available_streams) {
+            // If still at capacity (either no live stream was evictable or the
+            // eviction failed), check failovers
+            if ($activeStreams >= $limitPlaylist->available_streams) {
                     // Primary playlist is at capacity, check failovers
                     $failoverChannels = $channel->failoverChannels()
                         ->select([
@@ -1284,7 +1299,6 @@ class M3uProxyService
                     }
                 }
             }
-        }
 
         // Per-PlaylistAuth stream limit check (only applies when proxy is in use)
         if ($playlistAuthId && ! $this->checkAndEnforceAuthStreamLimit($playlistAuthId, $id)) {

--- a/app/Services/ProfileService.php
+++ b/app/Services/ProfileService.php
@@ -279,6 +279,14 @@ class ProfileService
                 return [null, null];
             }
 
+            // Prune stale reservations before counting capacity. A pending
+            // reservation (reservation:xxx) only lives as long as its reverse
+            // channel mapping (30s TTL). If the reverse key is gone, whoever
+            // held the slot never finalized or released it (deleted recording,
+            // missed webhook, crashed worker) — the slot is phantom and must
+            // not block new streams.
+            static::pruneStaleReservations($playlist);
+
             // Inside the lock: detect if this channel is already being served.
             // Prevents two simultaneous requests for the same channel from both
             // allocating a slot during the window before the first stream is visible
@@ -475,6 +483,52 @@ class ProfileService
         );
 
         return $proxyCount + static::countPendingReservations($profile);
+    }
+
+    /**
+     * Remove stale pending reservations for a playlist's profiles.
+     *
+     * Pending reservations (reservation:xxx) are written together with a
+     * reverse channel mapping that carries a 30-second TTL. A reservation
+     * whose reverse key has already expired is a phantom slot (the creator
+     * never finalized it and no webhook released it) — drop it from the
+     * profile's streams set so it stops blocking capacity.
+     */
+    public static function pruneStaleReservations(Playlist $playlist): void
+    {
+        try {
+            $profiles = $playlist->profiles()->where('enabled', true)->get();
+            foreach ($profiles as $profile) {
+                $streamsKey = static::getProfileStreamsKey($profile);
+                $members = Redis::smembers($streamsKey);
+
+                $stale = [];
+                foreach ($members as $member) {
+                    if (! str_starts_with($member, 'reservation:')) {
+                        continue;
+                    }
+                    if (! Redis::exists(static::getStreamChannelKey($member))) {
+                        $stale[] = $member;
+                    }
+                }
+
+                if ($stale !== []) {
+                    Redis::pipeline(function ($pipe) use ($streamsKey, $stale): void {
+                        $pipe->srem($streamsKey, ...$stale);
+                    });
+
+                    Log::info('Pruned stale profile reservations', [
+                        'profile_id' => $profile->id,
+                        'removed' => $stale,
+                    ]);
+                }
+            }
+        } catch (\Exception $e) {
+            Log::warning('Failed to prune stale profile reservations', [
+                'playlist_id' => $playlist->id,
+                'exception' => $e->getMessage(),
+            ]);
+        }
     }
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -56,6 +56,11 @@ return Application::configure(basePath: dirname(__DIR__))
             return in_array($request->route()?->getName(), [
                 'xtream.api.player',
                 'xtream.api.get',
+                'xtream.stream.live.root',
+                'xtream.stream.vod.root',
+                'xtream.stream.series.root',
+                'xtream.stream.timeshift.root',
+                'xtream.stream.direct',
             ], true) || $request->expectsJson();
         });
     })->create();

--- a/docs/ci-validation-checklist.md
+++ b/docs/ci-validation-checklist.md
@@ -1,0 +1,119 @@
+# CI Validation Checklist — m3u-editor & m3u-tv
+
+How to validate a PR locally before pushing, and what the CI gates actually run.
+Fork PRs have a GitHub first-time approval gate: workflow runs show
+`action_required` until a maintainer clicks "Approve and run" — checks
+"skipped" or never starting is that gate, not the branch.
+
+---
+
+## m3u-editor (Laravel/Pest)
+
+### CI pipeline (`.github/workflows/ci.yml`)
+| Job | Command (CI) | Notes |
+|---|---|---|
+| Code Quality | `composer install` + `npm ci` + `vendor/bin/pint --test` | pint.json enables `Pint/laravel_blade`, which shells out to Node — **Node + node_modules must exist before pint** |
+| Security Scan | `composer audit`, `npm audit`, `php artisan checkpoint:scan` | |
+| Tests | Postgres 16 + Redis services; `npm run build` then `php artisan test --parallel --processes=4 --recreate-databases` | Runs the FULL suite on Postgres |
+| Docker Build Validation | `docker build` with `GIT_BRANCH`/`GIT_COMMIT` build args | |
+
+### Local reproduction (scratch container)
+```bash
+# Scratch container with the repo mounted + php/node/composer
+docker run --rm --entrypoint sh -v "<repo>:/app" -w /app composer:2 -c \
+  "apk add --no-cache nodejs npm && \
+   composer install --no-interaction --prefer-dist --no-progress --ignore-platform-reqs && \
+   npm ci --no-audit --no-fund && \
+   php vendor/bin/pint --test"
+```
+Tests need the same env as CI (Postgres test role/db + Redis + a Vite build):
+```bash
+# On a dev box with a live m3u-editor container:
+# 1) Postgres: CREATE ROLE testing LOGIN PASSWORD 'testing' SUPERUSER; CREATE DATABASE m3ue_test OWNER testing;
+# 2) .env from .env.example + REVERB_APP_SECRET=123 + APP_KEY; touch database/jobs.sqlite
+# 3) Build assets (or copy the deployed container's public/build) — otherwise
+#    view-rendering tests 500 with ViteManifestNotFoundException
+docker run --rm --network container:<m3u-editor-container> -v "<repo>:/app" -w /app --entrypoint sh \
+  -e DB_CONNECTION=pg_test -e DB_HOST=127.0.0.1 -e DB_PORT=5432 \
+  -e TEST_DB_DATABASE=m3ue_test -e TEST_DB_USERNAME=testing -e TEST_DB_PASSWORD=testing \
+  -e REDIS_HOST=redis -e REDIS_SERVER_PORT=6379 -e REDIS_PASSWORD=<redis-pass> \
+  m3u-editor:<image> -c "php artisan test --parallel --processes=4 --recreate-databases"
+```
+Focused runs: pass the test file paths instead of the full suite.
+
+### Known gotchas
+- **Pint**: run with the SAME lockfile the CI resolves (pint version from
+  composer.lock). A locally-PASS does not guarantee the CI passes if your
+  vendor is stale — always run against the CI-equivalent install.
+- **Vite manifest**: view-rendering tests 500 without `public/build/manifest.json`.
+- **attempt_count default**: `dvr_recordings.attempt_count` defaults to 1 —
+  retry tests must pin it explicitly.
+- **Factory randomness**: `Channel::factory()` randomizes `enabled` — tests
+  that assert EPG-scoped UI must pin `'enabled' => true`.
+- **Queue**: tests of retrying jobs should `Queue::fake()` — the sync driver
+  runs delayed dispatches inline and makes attempt-count assertions racy.
+
+---
+
+## m3u-tv (Flutter)
+
+### CI pipeline (`.github/workflows/ci.yml`)
+| Gate | Command | Notes |
+|---|---|---|
+| detect | paths filter (lib/test/pubspec) | gates only run when relevant files change |
+| Flutter analyze and test | `flutter pub get`, `dart format --output=none --set-exit-if-changed lib test`, `flutter analyze lib test`, `flutter test` | Flutter **pinned to 3.44.8** |
+| desktop build jobs | `flutter build linux/windows --release` | gated on desktop-affecting paths |
+
+### Local reproduction
+```bash
+cd flutter_client
+flutter pub get
+dart format --output=none --set-exit-if-changed lib test   # exit 1 = unformatted
+flutter analyze lib test
+flutter test
+```
+Check the local Flutter version — a NEWER SDK flags lints/tests the pinned
+3.44.8 does not (and vice versa). `flutter --version` should match 3.44.8 for
+a faithful pre-PR check.
+
+### Known gotchas
+- **Format gate**: after any merge of the target branch, run `dart format lib
+  test` — the CI's `--set-exit-if-changed` fails on unformatted files.
+- **Environment-sensitive tests** (fail on newer SDKs but pass on the pinned
+  one): `release_matrix_documentation_test.dart`, `tvos_port_drift_test.dart`,
+  `transcoding_contract_test.dart`, some `push_token_lifecycle_test.dart`.
+  Verify against the BASE branch (`git worktree add <dir> <base>` + run the
+  same files) before chasing them — if they fail on the base too, they are
+  environment noise, not PR regressions.
+- **Analyzer**: use `mounted` (State) rather than `context.mounted` when the
+  lint complains about `State.context` across async gaps.
+
+---
+
+## Best practices before opening / updating a PR
+
+1. **Rebase onto the target branch (dev)** — resolve conflicts before pushing;
+   a 0-behind branch merges cleanly and keeps the PR diff reviewable.
+2. **Run the exact CI commands locally first** (tables above), not a
+   convenience subset.
+3. **Use a base worktree to isolate regressions**: `git worktree add <dir>
+   <merge-base>` then run the failing files there. Pass/fail on the base tells
+   you instantly whether a failure is your change or environment.
+4. **Make test data deterministic**: pin `enabled`, timestamps with generous
+   margins (`upcoming(60)` not `upcoming(2)`), uuids long enough for
+   substring truncation in debug logs, and explicit `attempt_count`.
+5. **Format before every commit**: `dart format lib test` (m3u-tv),
+   `vendor/bin/pint` (m3u-editor) — run pint against the CI-equivalent
+   install (Node + node_modules + same lockfile).
+6. **Commit logically** (feature/settings/fix splits) so reviewers and CI logs
+   map to behavior, not noise.
+7. **After pushing, watch the CI run** (GitHub Actions → your PR). Fork PRs
+   need an approval before the run starts — if it stays `action_required`,
+   ask the maintainers to approve it; "checks skipped" is that gate, not your
+   branch.
+8. **If CI fails**: download the failing job's log (Actions → job → download
+   log), find the `FAIL`/`⨯` lines, reproduce locally, fix, re-push. Repeat
+   until every job is green — the reviewer only sees the final state.
+9. **Keep the deployed system in sync** while iterating: the live container
+   must be rebuilt from the same commits being pushed (opcache has
+   `validate_timestamps=Off` — hot-patched PHP files never load in FPM).

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Route;
  * Routed by the integration's unique webhook_secret so no additional auth header is needed.
  */
 Route::post('webhooks/arr/{integration:webhook_secret}', [ArrWebhookController::class, 'receive'])
-    ->middleware('throttle:120,1')
+    ->middleware('throttle:300,1')
     ->name('webhooks.arr');
 
 /*
@@ -54,7 +54,7 @@ Route::prefix('m3u-proxy')->group(function () {
     // Authenticated by VerifyM3uProxyCallback (see routes below and M3uProxyService,
     // which embeds the shared token in the URL it hands to the proxy).
     Route::post('failover-resolver', [M3uProxyApiController::class, 'resolveFailoverUrl'])
-        ->middleware(['m3u-proxy.callback', 'throttle:120,1'])
+        ->middleware(['m3u-proxy.callback', 'throttle:300,1'])
         ->name('m3u-proxy.failover-resolver');
 
     // Player stream stop - called via sendBeacon when in-app player is closed.
@@ -71,12 +71,12 @@ Route::prefix('m3u-proxy')->group(function () {
     // Proxy webhook endpoint - called by m3u-proxy to notify of events.
     // Relies on `m3u-proxy:register-webhook` to register this endpoint with the proxy.
     Route::post('webhooks', [M3uProxyApiController::class, 'handleWebhook'])
-        ->middleware(['m3u-proxy.callback', 'throttle:120,1'])
+        ->middleware(['m3u-proxy.callback', 'throttle:300,1'])
         ->name('m3u-proxy.webhook');
 
     // Network broadcast callback - called by proxy when broadcast FFmpeg process exits
     Route::post('broadcast/callback', [M3uProxyApiController::class, 'handleBroadcastCallback'])
-        ->middleware(['m3u-proxy.callback', 'throttle:120,1'])
+        ->middleware(['m3u-proxy.callback', 'throttle:300,1'])
         ->name('m3u-proxy.broadcast.callback');
 });
 
@@ -111,7 +111,7 @@ Route::prefix('vod')->middleware('dispatcharr.auth')->group(function () {
  * Must live in api.php (not web.php) to avoid CSRF verification.
  */
 Route::post('dvr/callback', [DvrCallbackController::class, 'handle'])
-    ->middleware(['m3u-proxy.callback', 'throttle:120,1'])
+    ->middleware(['m3u-proxy.callback', 'throttle:300,1'])
     ->name('dvr.callback');
 
 /*

--- a/routes/api.php
+++ b/routes/api.php
@@ -131,7 +131,7 @@ Route::prefix('device')->group(function () {
 /*
  * TV app API routes (authenticated via Xtream credentials in URL path - no Sanctum)
  */
-Route::prefix('tv/{username}/{password}')->middleware('throttle:60,1')->group(function () {
+Route::prefix('tv/{username}/{password}')->middleware('throttle:tv-api')->group(function () {
     Route::get('notifications', [TvApiController::class, 'notifications'])
         ->name('tv.notifications');
     Route::post('notifications/{id}/read', [TvApiController::class, 'markRead'])

--- a/tests/Feature/CustomMergedPlaylistDvrRequestsAiostreamsParityTest.php
+++ b/tests/Feature/CustomMergedPlaylistDvrRequestsAiostreamsParityTest.php
@@ -176,7 +176,6 @@ it('schedules a dvr recording through a merged playlist auth using the owner-res
     $response->assertOk()->assertJson(['success' => true]);
 });
 
-
 it('inherits dvr/request/aiostreams settings on a PlaylistAlias from its effective playlist', function () {
     $realPlaylist = Playlist::factory()->for($this->user)->create();
 

--- a/tests/Feature/CustomMergedPlaylistDvrRequestsAiostreamsParityTest.php
+++ b/tests/Feature/CustomMergedPlaylistDvrRequestsAiostreamsParityTest.php
@@ -176,6 +176,7 @@ it('schedules a dvr recording through a merged playlist auth using the owner-res
     $response->assertOk()->assertJson(['success' => true]);
 });
 
+
 it('inherits dvr/request/aiostreams settings on a PlaylistAlias from its effective playlist', function () {
     $realPlaylist = Playlist::factory()->for($this->user)->create();
 

--- a/tests/Feature/DvrRecorderServiceTest.php
+++ b/tests/Feature/DvrRecorderServiceTest.php
@@ -118,6 +118,7 @@ it('resolves the URL through the proxy for a pooled-provider channel so a profil
     $mock->shouldReceive('startDvrBroadcast')->andReturn($recording->uuid);
     $mock->shouldReceive('getActiveStreamIdForChannel')->andReturnNull();
     $mock->shouldReceive('getStreamProxyUrl')->andReturn('');
+    $mock->shouldReceive('getActiveLiveStreams')->andReturn([]);
     app()->instance(M3uProxyService::class, $mock);
 
     app(DvrRecorderService::class)->start($recording);
@@ -142,6 +143,7 @@ it('falls back to the raw channel URL when proxy resolution fails for a pooled-p
     $mock->shouldReceive('startDvrBroadcast')->andReturn($recording->uuid);
     $mock->shouldReceive('getActiveStreamIdForChannel')->andReturnNull();
     $mock->shouldReceive('getStreamProxyUrl')->andReturn('');
+    $mock->shouldReceive('getActiveLiveStreams')->andReturn([]);
     app()->instance(M3uProxyService::class, $mock);
 
     app(DvrRecorderService::class)->start($recording);

--- a/tests/Feature/StartDvrRecordingNotificationTest.php
+++ b/tests/Feature/StartDvrRecordingNotificationTest.php
@@ -56,19 +56,33 @@ it('transitions to Failed and persists a TvNotification when recording fails to 
             'status' => DvrRecordingStatus::Scheduled,
             'title' => 'Evening News',
             'stream_url' => 'http://example.com/stream',
+            'scheduled_end' => now()->addHour(),
+            'attempt_count' => 0,
         ]);
 
     $exceptionMessage = 'FFmpeg binary not found';
     $recorder = Mockery::mock(DvrRecorderService::class);
     $recorder->shouldReceive('start')
-        ->once()
+        ->times(StartDvrRecording::MAX_START_ATTEMPTS)
         ->andThrow(new Exception($exceptionMessage));
     $this->app->instance(DvrRecorderService::class, $recorder);
 
     Event::fake([TvNotificationEvent::class]);
     Bus::fake([SendPushNotificationRelay::class]);
+    Queue::fake();
 
     $job = new StartDvrRecording($recording->id);
+
+    // Transient failures retry (bounded by MAX_START_ATTEMPTS): the first
+    // attempts keep the recording Scheduled and schedule the retry.
+    for ($attempt = 1; $attempt < StartDvrRecording::MAX_START_ATTEMPTS; $attempt++) {
+        $job->handle($recorder);
+        $recording->refresh();
+        expect($recording->status)->toBe(DvrRecordingStatus::Scheduled);
+        expect($recording->attempt_count)->toBe($attempt);
+    }
+
+    // The final attempt marks the recording Failed and notifies.
     $job->handle($recorder);
 
     $recording->refresh();


### PR DESCRIPTION
DVR capacity enforcement on top of upstream pooling:

- **DVR-wins pre-eviction**: a recording that can't get a proxy slot evicts the oldest LIVE-VIEWER stream (never a recording-backed stream) and notifies the evicted viewer via a persisted TV notification.
- **Live capacity counts DVR recordings** as active slots (Antenna recordings are direct HDHomeRun URLs with no proxy stream), keyed by the channel's source playlist so merged wrappers (available_streams=0) don't skip the check.
- **scheduleDvr** resolves the merged playlist's source DVR settings (2-step / Antenna), refuses fixed-tuner pools at schedule time when tuners are busy, and excludes profile pools from refusal (DVR-wins handles them at start).
- **Merged DVR endpoints** (recordings list/cancel/delete) resolve source-setting ids - the app's DVR list was empty for merged credentials before.
- **Stale recording reconciliation** marks broadcasts that aren't running as failed; StartDvrRecording retries 3x15s with forceFresh upstreams.
- **DVR URL resolution** routes through getChannelUrl when profiles are enabled OR enable_proxy is on.
- **Notifications**: DVR/eviction notifications attach to the viewer's authenticatable (the MergedPlaylist for merged credentials) instead of the DVR setting's source playlist, which the TV app's notification scope never queries.
- **api/tv/*** throttled per-credential (240/min) instead of per-IP (60/min) so the TV app's legitimate notification polling doesn't 429.