### PR TITLE
fix: Merged-target bouquet pickers reopen empty and drop selections on save

### DIFF
--- a/app/Filament/Forms/Components/MergedSourceGroupModalSelect.php
+++ b/app/Filament/Forms/Components/MergedSourceGroupModalSelect.php
@@ -83,20 +83,26 @@ class MergedSourceGroupModalSelect
                     ? SourceCategory::displayLabelsForIds($playlistIds, $ids, includePlaylistName: count($playlistIds) > 1)
                     : SourceGroup::displayLabelsForIds($playlistIds, $type, $ids, includePlaylistName: count($playlistIds) > 1);
             })
-            ->afterStateHydrated(function ($component, $state, $record, Get $get) use ($scopedQuery, $playlistIdsFor): void {
+            ->afterStateHydrated(function ($component, $state, $record, Get $get) use ($scopedQuery, $selectionKey, $playlistIdsFor): void {
                 // Hidden twin components are still hydrated; bail unless this is a
-                // merged-target record whose stored pairs need resolving to ids.
-                if (! $record?->merged_playlist_id || ! is_array($state) || empty($state)) {
+                // merged-target record whose stored pairs need resolving to ids. A
+                // non-empty $state means they already were (a re-fill) - leave it.
+                if (! $record?->merged_playlist_id || ! empty($state)) {
                     return;
                 }
-                if (! is_array($state[0] ?? null)) {
+                // The pairs are read from the record rather than $state: Filament's
+                // option state cast normalises multi-select state to scalars before
+                // this hook runs, which drops every {playlist_id, name} pair and
+                // would leave the picker empty (and the selections lost on save).
+                $pairs = PlaylistAlias::selectionPairs($record->group_selections[$selectionKey] ?? []);
+                if (empty($pairs)) {
                     return;
                 }
                 $playlistIds = $playlistIdsFor($get, $record);
                 if (empty($playlistIds)) {
                     return;
                 }
-                $component->state(self::pairsToSourceIds($scopedQuery($playlistIds), $state));
+                $component->state(self::pairsToSourceIds($scopedQuery($playlistIds), $pairs));
             })
             ->dehydrateStateUsing(function ($state, $record, Get $get) use ($scopedQuery, $selectionKey, $playlistIdsFor): array {
                 $playlistIds = $playlistIdsFor($get, $record);
@@ -138,11 +144,6 @@ class MergedSourceGroupModalSelect
      */
     private static function pairsToSourceIds(Builder $query, array $pairs): array
     {
-        $pairs = PlaylistAlias::selectionPairs($pairs);
-        if (empty($pairs)) {
-            return [];
-        }
-
         return $query->where(function (Builder $query) use ($pairs): void {
             foreach ($pairs as $pair) {
                 $query->orWhere(fn (Builder $query) => $query

--- a/tests/Feature/BouquetEditHydrationTest.php
+++ b/tests/Feature/BouquetEditHydrationTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Reopening a saved bouquet must show the groups that were selected: the edit
+ * form has to translate the persisted group_selections (provider-stable names,
+ * or {playlist_id, name} pairs for a merged target) back into the picker ids
+ * the ModalTableSelect renders as badges and pre-selects in its modal table.
+ */
+
+use App\Filament\Resources\Bouquets\Pages\ListBouquets;
+use App\Models\Bouquet;
+use App\Models\CustomPlaylist;
+use App\Models\MergedPlaylist;
+use App\Models\Playlist;
+use App\Models\SourceGroup;
+use App\Models\User;
+use Livewire\Features\SupportTesting\Testable;
+use Livewire\Livewire;
+
+/**
+ * The badge labels the visible picker for $key renders in the mounted edit form.
+ *
+ * @return array<int|string, string>
+ */
+function bouquetEditPickerLabels(Testable $component, string $key): array
+{
+    $page = $component->instance();
+    $schema = $page->{$page->getMountedActionSchemaName()};
+
+    return $schema->getComponent($key, withHidden: false)->getOptionLabels();
+}
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+});
+
+it('shows the saved groups of a standard-target bouquet when reopened for editing', function () {
+    $playlist = Playlist::factory()->for($this->user)->createQuietly();
+    $sports = SourceGroup::create(['name' => 'Hydrate Sports', 'playlist_id' => $playlist->id, 'type' => 'live']);
+    $news = SourceGroup::create(['name' => 'Hydrate News', 'playlist_id' => $playlist->id, 'type' => 'live']);
+    SourceGroup::create(['name' => 'Hydrate Unselected', 'playlist_id' => $playlist->id, 'type' => 'live']);
+
+    $bouquet = Bouquet::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $playlist->id,
+        'group_selections' => ['selected_groups' => ['Hydrate Sports', 'Hydrate News']],
+    ]);
+
+    $component = Livewire::test(ListBouquets::class)
+        ->mountTableAction('edit', $bouquet)
+        ->assertTableActionDataSet(function (array $state) use ($sports, $news): array {
+            expect($state['group_selections']['selected_groups'] ?? null)
+                ->toEqualCanonicalizing([$sports->id, $news->id]);
+
+            return [];
+        });
+
+    $labels = bouquetEditPickerLabels($component, 'group_selections.selected_groups');
+    expect(array_keys($labels))->toEqualCanonicalizing([$sports->id, $news->id])
+        ->and(array_values($labels))->toEqualCanonicalizing(['Hydrate Sports', 'Hydrate News']);
+});
+
+it('shows the saved groups of a custom-playlist-target bouquet when reopened for editing', function () {
+    $custom = CustomPlaylist::factory()->for($this->user)->create();
+
+    $bouquet = Bouquet::factory()->forCustomPlaylist($custom)->create([
+        'user_id' => $this->user->id,
+        'group_selections' => ['selected_groups' => ['Hydrate Custom Sports']],
+    ]);
+
+    $component = Livewire::test(ListBouquets::class)
+        ->mountTableAction('edit', $bouquet)
+        ->assertTableActionDataSet(['group_selections.selected_groups' => ['Hydrate Custom Sports']]);
+
+    expect(bouquetEditPickerLabels($component, 'group_selections.selected_groups'))
+        ->toBe(['Hydrate Custom Sports' => 'Hydrate Custom Sports']);
+});
+
+it('shows the saved groups of a merged-target bouquet when reopened for editing', function () {
+    $sourceA = Playlist::factory()->for($this->user)->createQuietly(['name' => 'Provider A']);
+    $sourceB = Playlist::factory()->for($this->user)->createQuietly(['name' => 'Provider B']);
+    $merged = MergedPlaylist::factory()->for($this->user)->create();
+    $merged->playlists()->attach([$sourceA->id, $sourceB->id]);
+
+    $aSports = SourceGroup::create(['playlist_id' => $sourceA->id, 'name' => 'Hydrate Sports', 'type' => 'live']);
+    $bSports = SourceGroup::create(['playlist_id' => $sourceB->id, 'name' => 'Hydrate Sports', 'type' => 'live']);
+    SourceGroup::create(['playlist_id' => $sourceA->id, 'name' => 'Hydrate News', 'type' => 'live']);
+
+    $bouquet = Bouquet::factory()->forMergedPlaylist($merged)->create([
+        'user_id' => $this->user->id,
+        'group_selections' => ['selected_groups' => [
+            ['playlist_id' => $sourceA->id, 'name' => 'Hydrate Sports'],
+            ['playlist_id' => $sourceB->id, 'name' => 'Hydrate Sports'],
+        ]],
+    ]);
+
+    $component = Livewire::test(ListBouquets::class)
+        ->mountTableAction('edit', $bouquet)
+        ->assertTableActionDataSet(function (array $state) use ($aSports, $bSports): array {
+            expect($state['group_selections']['selected_groups'] ?? null)
+                ->toEqualCanonicalizing([$aSports->id, $bSports->id]);
+
+            return [];
+        });
+
+    $labels = bouquetEditPickerLabels($component, 'group_selections.selected_groups');
+    expect(array_keys($labels))->toEqualCanonicalizing([$aSports->id, $bSports->id])
+        ->and(array_values($labels))->toEqualCanonicalizing(['Hydrate Sports (Provider A)', 'Hydrate Sports (Provider B)']);
+});
+
+it('keeps a merged-target bouquet\'s selections when it is saved again without touching the pickers', function () {
+    $sourceA = Playlist::factory()->for($this->user)->createQuietly(['name' => 'Provider A']);
+    $merged = MergedPlaylist::factory()->for($this->user)->create();
+    $merged->playlists()->attach([$sourceA->id]);
+    SourceGroup::create(['playlist_id' => $sourceA->id, 'name' => 'Hydrate Sports', 'type' => 'live']);
+
+    $bouquet = Bouquet::factory()->forMergedPlaylist($merged)->create([
+        'user_id' => $this->user->id,
+        'group_selections' => ['selected_groups' => [['playlist_id' => $sourceA->id, 'name' => 'Hydrate Sports']]],
+    ]);
+
+    Livewire::test(ListBouquets::class)
+        ->callTableAction('edit', $bouquet, data: ['name' => 'Renamed bouquet'])
+        ->assertHasNoTableActionErrors();
+
+    expect($bouquet->refresh()->getSelectedLiveGroupSelections())
+        ->toBe([['playlist_id' => $sourceA->id, 'name' => 'Hydrate Sports']]);
+});


### PR DESCRIPTION
## Summary

- Reopening a bouquet that targets a **merged playlist** showed empty group/category pickers, so every edit meant re-selecting everything. Saving that form then wiped the stored selections.
- Standard-playlist and custom-playlist targets are not affected.
- Regression introduced with the merged-playlist target added on #1484 (`d1fb4f8a`); the original #1391 branch had no merged targets, which is why it didn't show there.

## Root cause

Filament applies `OptionsArrayStateCast::set()` to a multi `ModalTableSelect`'s state *before* `afterStateHydrated` runs, and that cast fails closed on non-scalar items. The merged picker stores `{playlist_id, name}` pairs, so the hook always saw `$state === []` and bailed out. With no ids in state, `dehydrateStateUsing` then read the save as a deliberate clear (its never-silently-shrink guard only keeps entries that no longer resolve) and persisted `[]`.

## Fix

`MergedSourceGroupModalSelect::afterStateHydrated` now reads the pairs from `$record->group_selections[<key>]`, the same pattern `PlaylistAliasResource::persistedSourceSelection()` already uses for merged aliases, and skips when the state is already populated (a re-fill). `pairsToSourceIds()` drops its re-normalisation, which is redundant now that its only caller passes normalised pairs.

## Tests

`tests/Feature/BouquetEditHydrationTest.php`: reopen for standard, custom and merged targets (asserting picker state and the rendered picker labels), plus save-after-reopen for a merged target. The two merged cases fail without the fix. Ran together with `BouquetResourceTest` and `BouquetMergedPlaylistTest`: 19 passed. Pint clean.

## Checklist notes

- No user-facing strings added or changed, so no `lang/` updates.
- `checkpoint:scan`: the same pre-existing buckets as `dev` (hardcoded secrets in lang files, `orderByRaw`, `GitInfoService` `shell_exec`, `MediaServerProxyController` TLS); nothing in the changed files. No dependency changes.
- Merged-target bouquets that were saved from the broken edit form have already lost their selections and need re-picking once; nothing here can recover them.
- Not changed here (pre-existing, unrelated to merged targets): `SourceGroupModalSelect` decides whether to translate names with `is_string($state[0])`, so a standard-target bouquet whose first stored group name is all digits would not be translated to ids.
