### PR TITLE
fix: Enforce wrapper and source playlist stream caps independently, resolve DVR settings through Merged/CustomPlaylist

### DIFF
--- a/app/Filament/Clusters/Settings/Pages/ManageNavigationSettings.php
+++ b/app/Filament/Clusters/Settings/Pages/ManageNavigationSettings.php
@@ -29,12 +29,12 @@ class ManageNavigationSettings extends BaseSettingsPage
 
     public static function getNavigationLabel(): string
     {
-        return __('Navigation Menu');
+        return __('Navigation');
     }
 
     public function getTitle(): string
     {
-        return __('Navigation Menu');
+        return __('Navigation');
     }
 
     public function getSubheading(): ?string

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -18,6 +18,7 @@ use App\Models\Channel;
 use App\Models\CustomPlaylist;
 use App\Models\DvrRecording;
 use App\Models\DvrRecordingRule;
+use App\Models\DvrSetting;
 use App\Models\DynamicGroup;
 use App\Models\EmbyLibraryMapping;
 use App\Models\Epg;
@@ -3876,22 +3877,73 @@ class XtreamApiController extends Controller
      * the effective playlist's DvrSetting, and (for guest credentials) the
      * PlaylistAuth's own dvr_enabled flag. Both feature advertisement and every
      * direct DVR action must agree with this result.
+     *
+     * For a CustomPlaylist/MergedPlaylist wrapper, capability is granted if
+     * EITHER the wrapper's own DvrSetting is enabled OR any source Playlist
+     * behind it has DVR enabled — mirrors resolveDvrSettingIds() so a wrapper
+     * whose channels come from a DVR-enabled source isn't gated out before its
+     * recordings are even looked up.
      */
     private function dvrCapabilityGranted(
         Playlist|CustomPlaylist|MergedPlaylist|null $dvrPlaylist,
         string $authMethod,
         ?PlaylistAuth $playlistAuth
     ): bool {
-        return DvrCapabilityGate::granted(
-            $dvrPlaylist?->dvrSetting,
-            $playlistAuth,
-            $authMethod === 'playlist_auth'
+        if (! $dvrPlaylist) {
+            return false;
+        }
+
+        $settingIds = $this->resolveDvrSettingIds($dvrPlaylist);
+
+        if ($settingIds === []) {
+            return false;
+        }
+
+        return DvrSetting::whereIn('id', $settingIds)->get()->contains(
+            fn (DvrSetting $setting) => DvrCapabilityGate::granted($setting, $playlistAuth, $authMethod === 'playlist_auth')
         );
     }
 
     private function resolveDvrPlaylist($playlist): Playlist|CustomPlaylist|MergedPlaylist|null
     {
         return $this->resolveEffectivePlaylist($playlist);
+    }
+
+    /**
+     * Resolve every DVR setting id a playlist's recordings could be filed under: its own
+     * dvrSetting (if configured directly on it), plus the dvrSettings of the source
+     * Playlists behind it when it's a CustomPlaylist or MergedPlaylist wrapper. Used by the
+     * DVR list/get/cancel/delete endpoints so a recording remains visible and manageable no
+     * matter which of those it was scheduled against.
+     *
+     * @return array<int, int>
+     */
+    private function resolveDvrSettingIds($playlist): array
+    {
+        if ($playlist instanceof Playlist) {
+            return $playlist->dvrSetting ? [$playlist->dvrSetting->id] : [];
+        }
+
+        $sourcePlaylistIds = $playlist instanceof MergedPlaylist
+            ? DB::table('merged_playlist_playlist')
+                ->where('merged_playlist_id', $playlist->id)
+                ->pluck('playlist_id')
+            : $playlist->channels()
+                ->whereNotNull('channels.playlist_id')
+                ->pluck('channels.playlist_id')
+                ->unique();
+
+        $settingIds = DvrSetting::whereIn('playlist_id', $sourcePlaylistIds)
+            ->pluck('id')
+            ->toArray();
+
+        // Include the wrapper's own setting too, in case a recording was ever
+        // scheduled against it directly.
+        if ($playlist->dvrSetting) {
+            $settingIds[] = $playlist->dvrSetting->id;
+        }
+
+        return array_values(array_unique($settingIds));
     }
 
     /**
@@ -3980,9 +4032,9 @@ class XtreamApiController extends Controller
      */
     private function getDvrRecordings(Request $request, $playlist, string $username, string $password, ?PlaylistAuth $playlistAuth): \Illuminate\Http\JsonResponse
     {
-        $dvrSetting = $playlist->dvrSetting;
+        $dvrSettingIds = $this->resolveDvrSettingIds($playlist);
 
-        if (! $dvrSetting) {
+        if ($dvrSettingIds === []) {
             return response()->json([]);
         }
 
@@ -3990,7 +4042,7 @@ class XtreamApiController extends Controller
         $limit = min((int) $request->input('limit', 50), 200);
         $offset = (int) $request->input('offset', 0);
 
-        $query = DvrRecording::where('dvr_setting_id', $dvrSetting->id)
+        $query = DvrRecording::whereIn('dvr_setting_id', $dvrSettingIds)
             ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
             ->with(['channel', 'dvrSetting', 'recordingRule'])
             ->orderByDesc('scheduled_start');
@@ -4018,13 +4070,13 @@ class XtreamApiController extends Controller
             return response()->json(['error' => 'recording_id parameter is required'], 400);
         }
 
-        $dvrSetting = $playlist->dvrSetting;
+        $dvrSettingIds = $this->resolveDvrSettingIds($playlist);
 
-        if (! $dvrSetting) {
+        if ($dvrSettingIds === []) {
             return response()->json(['error' => 'DVR not configured for this playlist'], 404);
         }
 
-        $recording = DvrRecording::where('dvr_setting_id', $dvrSetting->id)
+        $recording = DvrRecording::whereIn('dvr_setting_id', $dvrSettingIds)
             ->where('uuid', $uuid)
             ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
             ->with(['channel', 'dvrSetting', 'recordingRule'])
@@ -4669,13 +4721,13 @@ class XtreamApiController extends Controller
             return response()->json(['error' => 'recording_id parameter is required'], 400);
         }
 
-        $dvrSetting = $playlist->dvrSetting;
+        $dvrSettingIds = $this->resolveDvrSettingIds($playlist);
 
-        if (! $dvrSetting) {
+        if ($dvrSettingIds === []) {
             return response()->json(['error' => 'DVR not configured for this playlist'], 404);
         }
 
-        $recording = DvrRecording::where('dvr_setting_id', $dvrSetting->id)
+        $recording = DvrRecording::whereIn('dvr_setting_id', $dvrSettingIds)
             ->where('uuid', $uuid)
             ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
             ->whereIn('status', [DvrRecordingStatus::Scheduled, DvrRecordingStatus::Recording])
@@ -4714,13 +4766,13 @@ class XtreamApiController extends Controller
             return response()->json(['error' => 'recording_id parameter is required'], 400);
         }
 
-        $dvrSetting = $playlist->dvrSetting;
+        $dvrSettingIds = $this->resolveDvrSettingIds($playlist);
 
-        if (! $dvrSetting) {
+        if ($dvrSettingIds === []) {
             return response()->json(['error' => 'DVR not configured for this playlist'], 404);
         }
 
-        $recording = DvrRecording::where('dvr_setting_id', $dvrSetting->id)
+        $recording = DvrRecording::whereIn('dvr_setting_id', $dvrSettingIds)
             ->where('uuid', $uuid)
             ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
             ->whereIn('status', [

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -3948,6 +3948,37 @@ class XtreamApiController extends Controller
     }
 
     /**
+     * Resolve the single DvrSetting a new recording/rule should be written against,
+     * when accessed through a CustomPlaylist/MergedPlaylist wrapper. Mirrors
+     * resolveDvrSettingIds()'s read-side resolution, but a write needs exactly one
+     * target: prefers the given channel's own source Playlist's DvrSetting (so
+     * scheduling a specific channel through a wrapper always lands on the right
+     * source, even when the wrapper spans multiple DVR-enabled sources), then falls
+     * back to the wrapper's own DvrSetting, then the first DVR-enabled source
+     * resolved via resolveDvrSettingIds() (covers the "any channel" series-rule case).
+     */
+    private function resolveDvrSettingForWrite($playlist, ?int $channelId = null): ?DvrSetting
+    {
+        if ($channelId) {
+            $channel = $playlist->channels()->where('channels.id', $channelId)->first();
+            if ($channel?->playlist_id) {
+                $setting = DvrSetting::where('playlist_id', $channel->playlist_id)->first();
+                if ($setting) {
+                    return $setting;
+                }
+            }
+        }
+
+        if ($playlist->dvrSetting) {
+            return $playlist->dvrSetting;
+        }
+
+        $settingIds = $this->resolveDvrSettingIds($playlist);
+
+        return $settingIds === [] ? null : DvrSetting::find($settingIds[0]);
+    }
+
+    /**
      * Get short EPG for an attached network on custom/merged playlists.
      * Stream ID format: network-{id}
      */
@@ -4117,9 +4148,9 @@ class XtreamApiController extends Controller
             ]);
         }
 
-        $dvrSetting = $playlist->dvrSetting;
+        $dvrSettingIds = $this->resolveDvrSettingIds($playlist);
 
-        if (! $dvrSetting) {
+        if ($dvrSettingIds === []) {
             return response()->json([
                 'used_bytes' => 0,
                 'quota_bytes' => null,
@@ -4129,16 +4160,17 @@ class XtreamApiController extends Controller
             ]);
         }
 
-        $usedBytes = $dvrSetting->storage_used_bytes;
-        $quotaBytes = $dvrSetting->global_disk_quota_gb > 0
-            ? $dvrSetting->global_disk_quota_gb * 1024 ** 3
-            : null;
+        $dvrSettings = DvrSetting::whereIn('id', $dvrSettingIds)->get();
+
+        $usedBytes = (int) $dvrSettings->sum('storage_used_bytes');
+        $quotaBytes = $dvrSettings->sum(fn (DvrSetting $s) => $s->global_disk_quota_gb > 0 ? $s->global_disk_quota_gb * 1024 ** 3 : 0) ?: null;
+        $recordingCount = DvrRecording::whereIn('dvr_setting_id', $dvrSettingIds)->count();
 
         return response()->json([
             'used_bytes' => $usedBytes,
             'quota_bytes' => $quotaBytes,
             'percent_used' => $quotaBytes ? min(100, round($usedBytes / $quotaBytes * 100, 1)) : null,
-            'recording_count' => $dvrSetting->recordings()->count(),
+            'recording_count' => $recordingCount,
             'scope' => 'account',
         ]);
     }
@@ -4148,13 +4180,13 @@ class XtreamApiController extends Controller
      */
     private function listDvrSeriesRules(Request $request, $playlist, ?PlaylistAuth $playlistAuth): \Illuminate\Http\JsonResponse
     {
-        $dvrSetting = $playlist->dvrSetting;
+        $dvrSettingIds = $this->resolveDvrSettingIds($playlist);
 
-        if (! $dvrSetting) {
+        if ($dvrSettingIds === []) {
             return response()->json([]);
         }
 
-        $rules = DvrRecordingRule::where('dvr_setting_id', $dvrSetting->id)
+        $rules = DvrRecordingRule::whereIn('dvr_setting_id', $dvrSettingIds)
             ->where('type', DvrRuleType::Series)
             ->where('enabled', true)
             ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
@@ -4177,13 +4209,13 @@ class XtreamApiController extends Controller
             return response()->json(['error' => 'rule_id parameter is required'], 400);
         }
 
-        $dvrSetting = $playlist->dvrSetting;
+        $dvrSettingIds = $this->resolveDvrSettingIds($playlist);
 
-        if (! $dvrSetting) {
+        if ($dvrSettingIds === []) {
             return response()->json(['error' => 'DVR not configured for this playlist'], 404);
         }
 
-        $rule = DvrRecordingRule::where('dvr_setting_id', $dvrSetting->id)
+        $rule = DvrRecordingRule::whereIn('dvr_setting_id', $dvrSettingIds)
             ->where('id', $ruleId)
             ->where('type', DvrRuleType::Series)
             ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
@@ -4213,20 +4245,20 @@ class XtreamApiController extends Controller
             return response()->json(['error' => 'q parameter is required (minimum 2 characters)'], 400);
         }
 
-        $dvrSetting = $playlist->dvrSetting;
+        $dvrSettingIds = $this->resolveDvrSettingIds($playlist);
 
-        if (! $dvrSetting?->enabled) {
+        if ($dvrSettingIds === [] || ! DvrSetting::whereIn('id', $dvrSettingIds)->where('enabled', true)->exists()) {
             return response()->json(['error' => 'DVR is not enabled for this playlist'], 422);
         }
 
-        // Pre-fetch the set of existing Series rules for this DVR setting (scoped by
+        // Pre-fetch the set of existing Series rules for these DVR settings (scoped by
         // playlist_auth when applicable) keyed by their auto-derived normalized_title,
         // so each result can advertise `has_series_rule` + `series_rule_id` without
         // a per-group query. Uses the same SeriesKey::normalize normalization as the
         // grouping below — which matches DvrRecordingRule::saving's column population —
         // so a normalized-title lookup here is consistent with what a future rule
         // created from this result would store.
-        $seriesRuleTitles = DvrRecordingRule::where('dvr_setting_id', $dvrSetting->id)
+        $seriesRuleTitles = DvrRecordingRule::whereIn('dvr_setting_id', $dvrSettingIds)
             ->where('type', DvrRuleType::Series)
             ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
             ->pluck('id', 'normalized_title');
@@ -4441,7 +4473,8 @@ class XtreamApiController extends Controller
             return response()->json(['error' => 'channel_id, title, start_time, and end_time are required'], 400);
         }
 
-        $dvrSetting = $playlist->dvrSetting?->enabled ? $playlist->dvrSetting : null;
+        $dvrSetting = $this->resolveDvrSettingForWrite($playlist, $channelId);
+        $dvrSetting = $dvrSetting?->enabled ? $dvrSetting : null;
 
         if (! $dvrSetting) {
             return response()->json(['error' => 'DVR is not enabled for this playlist'], 422);
@@ -4523,7 +4556,8 @@ class XtreamApiController extends Controller
             return response()->json(['error' => 'title is required'], 400);
         }
 
-        $dvrSetting = $playlist->dvrSetting?->enabled ? $playlist->dvrSetting : null;
+        $dvrSetting = $this->resolveDvrSettingForWrite($playlist, $channelId);
+        $dvrSetting = $dvrSetting?->enabled ? $dvrSetting : null;
 
         if (! $dvrSetting) {
             return response()->json(['error' => 'DVR is not enabled for this playlist'], 422);
@@ -4631,13 +4665,13 @@ class XtreamApiController extends Controller
             return response()->json(['error' => 'rule_id parameter is required'], 400);
         }
 
-        $dvrSetting = $playlist->dvrSetting;
+        $dvrSettingIds = $this->resolveDvrSettingIds($playlist);
 
-        if (! $dvrSetting) {
+        if ($dvrSettingIds === []) {
             return response()->json(['error' => 'DVR not configured for this playlist'], 404);
         }
 
-        $rule = DvrRecordingRule::where('dvr_setting_id', $dvrSetting->id)
+        $rule = DvrRecordingRule::whereIn('dvr_setting_id', $dvrSettingIds)
             ->where('id', $ruleId)
             ->where('type', DvrRuleType::Series)
             ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -3930,8 +3930,9 @@ class XtreamApiController extends Controller
                 ->pluck('playlist_id')
             : $playlist->channels()
                 ->whereNotNull('channels.playlist_id')
-                ->pluck('channels.playlist_id')
-                ->unique();
+                ->groupBy('channels.playlist_id')
+                ->distinct()
+                ->pluck('channels.playlist_id');
 
         $settingIds = DvrSetting::whereIn('playlist_id', $sourcePlaylistIds)
             ->pluck('id')

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -401,6 +401,104 @@ class M3uProxyService
     }
 
     /**
+     * Get the DISTINCT channel ids currently being watched live under the given
+     * playlist UUID, whether the stream was opened directly against that playlist
+     * (metadata `playlist_uuid`) or through a wrapper (CustomPlaylist/MergedPlaylist)
+     * whose channels resolve back to it (metadata `source_playlist_uuid`).
+     *
+     * Used by DVR capacity accounting so a wrapper's own limit and its source
+     * playlist's limit (e.g. a tuner pool) can each be enforced against the
+     * streams that actually count toward them.
+     *
+     * @return array<int, int>
+     */
+    public static function getActiveLiveChannelIds(string $playlistUuid): array
+    {
+        $ids = [];
+
+        foreach (['playlist_uuid', 'source_playlist_uuid'] as $field) {
+            $service = new self;
+
+            if (empty($service->apiBaseUrl)) {
+                return [];
+            }
+
+            try {
+                $response = Http::timeout(5)->acceptJson()
+                    ->withHeaders($service->apiToken ? ['X-API-Token' => $service->apiToken] : [])
+                    ->get($service->apiBaseUrl.'/streams/by-metadata', [
+                        'field' => $field,
+                        'value' => $playlistUuid,
+                        'active_only' => true,
+                    ]);
+
+                if (! $response->successful()) {
+                    continue;
+                }
+
+                foreach ($response->json('matching_streams') ?? [] as $stream) {
+                    $channelId = $stream['metadata']['channel_id'] ?? $stream['metadata']['id'] ?? null;
+                    if ($channelId !== null) {
+                        $ids[(int) $channelId] = true;
+                    }
+                }
+            } catch (Exception $e) {
+                Log::warning('Error listing active live channels', [
+                    'metadata_field' => $field,
+                    'exception' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return array_keys($ids);
+    }
+
+    /**
+     * List active live streams on the proxy, including their metadata and
+     * creation time. Used to pick the oldest LIVE-VIEWER stream to evict when
+     * a playlist is at capacity, while excluding DVR-recording-backed channels.
+     *
+     * @return array<int, array{stream_id: string, created_at: ?string, metadata: array}>
+     */
+    public function getActiveLiveStreams(): array
+    {
+        if (empty($this->apiBaseUrl)) {
+            return [];
+        }
+
+        try {
+            $response = Http::timeout(5)->acceptJson()
+                ->withHeaders($this->apiToken ? ['X-API-Token' => $this->apiToken] : [])
+                ->get($this->apiBaseUrl.'/streams');
+
+            if (! $response->successful()) {
+                return [];
+            }
+
+            $result = [];
+            foreach ($response->json('streams') ?? [] as $stream) {
+                if (! ($stream['is_active'] ?? false) || (int) ($stream['client_count'] ?? 0) === 0) {
+                    continue;
+                }
+
+                $result[] = [
+                    'stream_id' => (string) ($stream['stream_id'] ?? ''),
+                    'created_at' => $stream['created_at'] ?? null,
+                    'metadata' => $stream['metadata'] ?? [],
+                ];
+            }
+
+            return $result;
+        } catch (Exception $e) {
+            Log::warning('Failed to list active live streams', [
+                'exception' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
+    }
+
+    /**
      * Get active stream counts for multiple metadata values in a single request.
      *
      * Returns a map of value → stream count. Values not found in the proxy
@@ -941,6 +1039,13 @@ class M3uProxyService
         $originalChannelId = $channel->id;
         $originalPlaylistUuid = $playlist->uuid;
 
+        // The channel's true source Playlist, if it has one — distinct from $playlist,
+        // which may be a CustomPlaylist/MergedPlaylist/PlaylistAlias wrapper. Tagged on
+        // every stream (regardless of profiles_enabled) so DVR capacity accounting can
+        // enforce a source-level limit (e.g. a tuner pool) even when the channel is only
+        // ever accessed through an unlimited wrapper.
+        $sourcePlaylist = $channel->playlist instanceof Playlist ? $channel->playlist : null;
+
         // Build client identifier for profile affinity tracking
         $clientIdentifier = ProfileService::buildClientIdentifier($request?->ip(), $username);
 
@@ -1134,85 +1239,131 @@ class M3uProxyService
             }
         }
 
-        // Check if primary playlist has stream limits and if it's at capacity
-        // Only check capacity if we're about to create a NEW stream (no existing pooled stream found)
-        // This check applies regardless of whether provider profiles are enabled —
-        // available_streams is the authoritative proxy-level limit.
+        // Check if the playlist(s) this request counts against have stream limits and are
+        // at capacity. Only check capacity if we're about to create a NEW stream (no
+        // existing pooled stream found). This check applies regardless of whether provider
+        // profiles are enabled — available_streams is the authoritative proxy-level limit.
+        //
+        // A wrapper playlist (CustomPlaylist/MergedPlaylist/PlaylistAlias) and the channel's
+        // true source Playlist can each carry their own independent cap (e.g. a MergedPlaylist
+        // limiting guest connections, wrapping an HDHomeRun-style source with a hard tuner
+        // limit) — both are enforced.
         $primaryUrl = null;
         $actualChannel = $channel;  // Track the actual channel being used (may differ from original if failover)
 
-        if ($playlist->available_streams !== 0) {
-            $activeStreams = self::getActiveStreamsCountByMetadata('playlist_uuid', $playlist->uuid);
+        $capacityLimitPlaylists = collect([$sourcePlaylist, $playlist])
+            ->filter()
+            ->unique('uuid')
+            ->filter(fn ($p) => $p->available_streams !== 0)
+            ->values();
 
+        if ($capacityLimitPlaylists->isNotEmpty()) {
             // Keep track of original playlist in case we need to check failovers
             $originalUuid = $playlist->uuid;
+            $deniedPlaylist = null;
 
-            if ($activeStreams >= $playlist->available_streams) {
-                // Check if "stop oldest on limit" is enabled in settings
-                if ($this->stopOldestOnLimit) {
-                    // Stop the oldest stream to make room for the new one (latest wins)
-                    $stopResult = self::stopOldestPlaylistStream($playlist->uuid, $id);
+            foreach ($capacityLimitPlaylists as $limitPlaylist) {
+                // DVR recordings hold their slot unconditionally (never evicted below), so
+                // count them alongside live viewers against this playlist's limit. Direct-URL
+                // playlists (e.g. HDHomeRun tuners) never create a proxy stream for a
+                // recording, so counting live streams alone would let extra live viewers in
+                // while recordings still occupy the underlying tuners.
+                $dvrChannelIds = $limitPlaylist->dvrSetting
+                    ? $limitPlaylist->dvrSetting->recordings()
+                        ->where('status', DvrRecordingStatus::Recording)
+                        ->pluck('channel_id')
+                        ->map(fn ($c) => (int) $c)
+                        ->all()
+                    : [];
 
-                    if ($stopResult['deleted_count'] > 0) {
-                        Log::debug('Stopped oldest stream to free capacity for new channel request', [
-                            'channel_id' => $id,
-                            'playlist_uuid' => $playlist->uuid,
-                            'stream_age_seconds' => $stopResult['stream_age_seconds'] ?? null,
-                        ]);
+                $liveIds = array_map('intval', self::getActiveLiveChannelIds($limitPlaylist->uuid));
+                $activeStreams = count(array_unique(array_merge($liveIds, $dvrChannelIds)));
 
-                        // Short delay to allow proxy to clean up
-                        usleep(100000); // 100ms
-                        $activeStreams = self::getActiveStreamsCountByMetadata('playlist_uuid', $playlist->uuid);
+                if ($activeStreams >= $limitPlaylist->available_streams) {
+                    // Check if "stop oldest on limit" is enabled in settings
+                    if ($this->stopOldestOnLimit) {
+                        // DVR-wins: recordings keep their slot, so evict the oldest
+                        // LIVE-VIEWER stream tied to this playlist (never a recording-backed
+                        // one, and never the channel being requested) to make room.
+                        $liveCandidates = collect($this->getActiveLiveStreams())
+                            ->filter(fn (array $s) => ($s['metadata']['playlist_uuid'] ?? null) === $limitPlaylist->uuid
+                                || ($s['metadata']['source_playlist_uuid'] ?? null) === $limitPlaylist->uuid)
+                            ->filter(fn (array $s) => (int) ($s['metadata']['channel_id'] ?? $s['metadata']['id'] ?? 0) !== (int) $id)
+                            ->filter(fn (array $s) => ! in_array((int) ($s['metadata']['channel_id'] ?? $s['metadata']['id'] ?? 0), $dvrChannelIds, true))
+                            ->sortBy(fn (array $s) => (string) ($s['created_at'] ?? ''))
+                            ->values();
+
+                        if ($liveCandidates->isNotEmpty()) {
+                            $oldest = $liveCandidates->first();
+                            $this->stopStream((string) $oldest['stream_id']);
+
+                            Log::debug('Stopped oldest live stream to free capacity for new channel request', [
+                                'channel_id' => $id,
+                                'limit_playlist_uuid' => $limitPlaylist->uuid,
+                                'evicted_stream_id' => $oldest['stream_id'],
+                                'evicted_channel_id' => $oldest['metadata']['channel_id'] ?? $oldest['metadata']['id'] ?? null,
+                            ]);
+
+                            // Short delay to allow proxy to clean up
+                            usleep(100000); // 100ms
+                            $liveIds = array_map('intval', self::getActiveLiveChannelIds($limitPlaylist->uuid));
+                            $activeStreams = count(array_unique(array_merge($liveIds, $dvrChannelIds)));
+                        }
+                    }
+
+                    // If still at capacity (either setting disabled, or no evictable
+                    // live stream was found), this playlist denies the request.
+                    if ($activeStreams >= $limitPlaylist->available_streams) {
+                        $deniedPlaylist = $limitPlaylist;
+                        break;
                     }
                 }
+            }
 
-                // If still at capacity (either setting disabled or stop failed), check failovers
-                if ($activeStreams >= $playlist->available_streams) {
-                    // Primary playlist is at capacity, check failovers
-                    $failoverChannels = $channel->failoverChannels()
-                        ->select([
-                            'channels.id',
-                            'channels.url',
-                            'channels.url_custom',
-                            'channels.playlist_id',
-                            'channels.custom_playlist_id',
-                        ])->get();
+            if ($deniedPlaylist) {
+                // Primary/source playlist is at capacity, check failovers
+                $failoverChannels = $channel->failoverChannels()
+                    ->select([
+                        'channels.id',
+                        'channels.url',
+                        'channels.url_custom',
+                        'channels.playlist_id',
+                        'channels.custom_playlist_id',
+                    ])->get();
 
-                    foreach ($failoverChannels as $failoverChannel) {
-                        $failoverPlaylist = $failoverChannel->getEffectivePlaylist();
+                foreach ($failoverChannels as $failoverChannel) {
+                    $failoverPlaylist = $failoverChannel->getEffectivePlaylist();
 
-                        // Check if failover playlist has limits and capacity
-                        if ($failoverPlaylist->available_streams === 0) {
-                            // No limits on this failover playlist, use it
+                    // Check if failover playlist has limits and capacity
+                    if ($failoverPlaylist->available_streams === 0) {
+                        // No limits on this failover playlist, use it
+                        $playlist = $failoverPlaylist;
+                        $actualChannel = $failoverChannel;  // Track that we're using a failover channel
+                        $primaryUrl = PlaylistUrlService::getChannelUrl($failoverChannel, $playlist);
+                        break;
+                    } else {
+                        // Check if failover playlist has capacity
+                        $failoverActiveStreams = self::getActiveStreamsCountByMetadata('playlist_uuid', $failoverPlaylist->uuid);
+
+                        if ($failoverActiveStreams < $failoverPlaylist->available_streams) {
+                            // Found available failover playlist
                             $playlist = $failoverPlaylist;
                             $actualChannel = $failoverChannel;  // Track that we're using a failover channel
                             $primaryUrl = PlaylistUrlService::getChannelUrl($failoverChannel, $playlist);
                             break;
-                        } else {
-                            // Check if failover playlist has capacity
-                            $failoverActiveStreams = self::getActiveStreamsCountByMetadata('playlist_uuid', $failoverPlaylist->uuid);
-
-                            if ($failoverActiveStreams < $failoverPlaylist->available_streams) {
-                                // Found available failover playlist
-                                $playlist = $failoverPlaylist;
-                                $actualChannel = $failoverChannel;  // Track that we're using a failover channel
-                                $primaryUrl = PlaylistUrlService::getChannelUrl($failoverChannel, $playlist);
-                                break;
-                            }
                         }
                     }
+                }
 
-                    // If we still have the original playlist, all are at capacity
-                    if ($playlist->uuid === $originalUuid) {
-                        Log::debug('Channel stream request denied - all playlists at capacity', [
-                            'channel_id' => $id,
-                            'primary_playlist' => $playlist->uuid,
-                            'primary_limit' => $playlist->available_streams,
-                            'primary_active' => $activeStreams,
-                        ]);
+                // If we still have the original playlist, all are at capacity
+                if ($playlist->uuid === $originalUuid) {
+                    Log::debug('Channel stream request denied - all playlists at capacity', [
+                        'channel_id' => $id,
+                        'denied_playlist' => $deniedPlaylist->uuid,
+                        'denied_limit' => $deniedPlaylist->available_streams,
+                    ]);
 
-                        abort(503, 'All playlists have reached their maximum stream limit. Please try again later.');
-                    }
+                    abort(503, 'All playlists have reached their maximum stream limit. Please try again later.');
                 }
             }
         }
@@ -1372,6 +1523,7 @@ class M3uProxyService
                 'profile_id' => $profile->id,
                 'original_channel_id' => $originalChannelId,  // For cross-provider failover pooling
                 'original_playlist_uuid' => $originalPlaylistUuid,  // For cross-provider failover pooling
+                'source_playlist_uuid' => $actualChannel->playlist instanceof Playlist ? $actualChannel->playlist->uuid : null,  // For DVR capacity accounting
                 'is_failover' => $isFailover,
                 'strict_live_ts' => $playlist->strict_live_ts ?? false,
                 'use_sticky_session' => $playlist->use_sticky_session ?? false,
@@ -1442,6 +1594,7 @@ class M3uProxyService
                 'use_sticky_session' => $playlist->use_sticky_session ?? false,
                 'original_channel_id' => $originalChannelId,  // For cross-provider failover pooling
                 'original_playlist_uuid' => $originalPlaylistUuid,  // For cross-provider failover pooling
+                'source_playlist_uuid' => $actualChannel->playlist instanceof Playlist ? $actualChannel->playlist->uuid : null,  // For DVR capacity accounting
                 'is_failover' => $isFailover,
             ];
 

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -454,6 +454,58 @@ class M3uProxyService
     }
 
     /**
+     * Same as getActiveLiveChannelIds(), but for VOD episode streams (metadata
+     * `episode_id`/`id` instead of `channel_id`). Used for wrapper-aware
+     * capacity accounting in getEpisodeUrl().
+     *
+     * @return array<int, int>
+     */
+    public static function getActiveLiveEpisodeIds(string $playlistUuid): array
+    {
+        $ids = [];
+
+        foreach (['playlist_uuid', 'source_playlist_uuid'] as $field) {
+            $service = new self;
+
+            if (empty($service->apiBaseUrl)) {
+                return [];
+            }
+
+            try {
+                $response = Http::timeout(5)->acceptJson()
+                    ->withHeaders($service->apiToken ? ['X-API-Token' => $service->apiToken] : [])
+                    ->get($service->apiBaseUrl.'/streams/by-metadata', [
+                        'field' => $field,
+                        'value' => $playlistUuid,
+                        'active_only' => true,
+                    ]);
+
+                if (! $response->successful()) {
+                    continue;
+                }
+
+                foreach ($response->json('matching_streams') ?? [] as $stream) {
+                    if (($stream['metadata']['type'] ?? null) !== 'episode') {
+                        continue;
+                    }
+
+                    $episodeId = $stream['metadata']['episode_id'] ?? $stream['metadata']['id'] ?? null;
+                    if ($episodeId !== null) {
+                        $ids[(int) $episodeId] = true;
+                    }
+                }
+            } catch (Exception $e) {
+                Log::warning('Error listing active live episodes', [
+                    'metadata_field' => $field,
+                    'exception' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return array_keys($ids);
+    }
+
+    /**
      * List active live streams on the proxy, including their metadata and
      * creation time. Used to pick the oldest LIVE-VIEWER stream to evict when
      * a playlist is at capacity, while excluding DVR-recording-backed channels.
@@ -1666,6 +1718,11 @@ class M3uProxyService
         $originalEpisodeId = $id;
         $originalPlaylistUuid = $playlist->uuid;
 
+        // The episode's true source Playlist, if it has one — distinct from $playlist,
+        // which may be a CustomPlaylist/MergedPlaylist/PlaylistAlias wrapper. See
+        // getChannelUrl() for why this is tagged/enforced independently of profiles_enabled.
+        $sourcePlaylist = $episode->playlist instanceof Playlist ? $episode->playlist : null;
+
         // Build client identifier for profile affinity tracking
         $clientIdentifier = ProfileService::buildClientIdentifier($request?->ip(), $username);
 
@@ -1689,75 +1746,104 @@ class M3uProxyService
         // Cached failover episodes so the relationship is only queried once per request
         $cachedFailoverEpisodes = null;
 
-        // Check if playlist has stream limits and if it's at capacity
-        // This check applies regardless of whether provider profiles are enabled —
-        // available_streams is the authoritative proxy-level limit.
-        if ($playlist->available_streams !== 0) {
-            $activeStreams = self::getActiveStreamsCountByMetadata('playlist_uuid', $playlist->uuid);
+        // Check if the playlist(s) this request counts against have stream limits and are
+        // at capacity. A wrapper playlist (CustomPlaylist/MergedPlaylist/PlaylistAlias) and
+        // the episode's true source Playlist can each carry their own independent cap — see
+        // getChannelUrl() for the equivalent live-channel logic this mirrors.
+        $capacityLimitPlaylists = collect([$sourcePlaylist, $playlist])
+            ->filter()
+            ->unique('uuid')
+            ->filter(fn ($p) => $p->available_streams !== 0)
+            ->values();
 
-            if ($activeStreams >= $playlist->available_streams) {
-                // Check if "stop oldest on limit" is enabled in settings
-                if ($this->stopOldestOnLimit) {
-                    // Stop the oldest stream to make room for the new one (latest wins)
-                    $stopResult = self::stopOldestPlaylistStream($playlist->uuid, $id);
+        if ($capacityLimitPlaylists->isNotEmpty()) {
+            $deniedPlaylist = null;
+            $activeStreams = 0;
 
-                    if ($stopResult['deleted_count'] > 0) {
-                        Log::debug('Stopped oldest stream to free capacity for new episode request', [
-                            'episode_id' => $id,
-                            'playlist_uuid' => $playlist->uuid,
-                            'stream_age_seconds' => $stopResult['stream_age_seconds'] ?? null,
-                        ]);
+            foreach ($capacityLimitPlaylists as $limitPlaylist) {
+                $activeStreams = count(self::getActiveLiveEpisodeIds($limitPlaylist->uuid));
 
-                        // Short delay to allow proxy to clean up
-                        usleep(100000); // 100ms
-                        $activeStreams = self::getActiveStreamsCountByMetadata('playlist_uuid', $playlist->uuid);
+                if ($activeStreams >= $limitPlaylist->available_streams) {
+                    // Check if "stop oldest on limit" is enabled in settings
+                    if ($this->stopOldestOnLimit) {
+                        // Evict the oldest LIVE episode stream tied to this playlist (never
+                        // the episode being requested) to make room for the new one.
+                        $liveCandidates = collect($this->getActiveLiveStreams())
+                            ->filter(fn (array $s) => ($s['metadata']['type'] ?? null) === 'episode')
+                            ->filter(fn (array $s) => ($s['metadata']['playlist_uuid'] ?? null) === $limitPlaylist->uuid
+                                || ($s['metadata']['source_playlist_uuid'] ?? null) === $limitPlaylist->uuid)
+                            ->filter(fn (array $s) => (int) ($s['metadata']['episode_id'] ?? $s['metadata']['id'] ?? 0) !== (int) $id)
+                            ->sortBy(fn (array $s) => (string) ($s['created_at'] ?? ''))
+                            ->values();
+
+                        if ($liveCandidates->isNotEmpty()) {
+                            $oldest = $liveCandidates->first();
+                            $this->stopStream((string) $oldest['stream_id']);
+
+                            Log::debug('Stopped oldest episode stream to free capacity for new episode request', [
+                                'episode_id' => $id,
+                                'limit_playlist_uuid' => $limitPlaylist->uuid,
+                                'evicted_stream_id' => $oldest['stream_id'],
+                            ]);
+
+                            // Short delay to allow proxy to clean up
+                            usleep(100000); // 100ms
+                            $activeStreams = count(self::getActiveLiveEpisodeIds($limitPlaylist->uuid));
+                        }
+                    }
+
+                    // If still at capacity (either setting disabled, or no evictable
+                    // live stream was found), this playlist denies the request.
+                    if ($activeStreams >= $limitPlaylist->available_streams) {
+                        $deniedPlaylist = $limitPlaylist;
+                        break;
+                    }
+                }
+            }
+
+            // If still at capacity, try episode failovers.
+            if ($deniedPlaylist) {
+                $cachedFailoverEpisodes = $requestedEpisode->failoverEpisodes()->with('playlist')->get();
+                foreach ($cachedFailoverEpisodes as $failoverEpisode) {
+                    $failoverPlaylist = $failoverEpisode->getEffectivePlaylist();
+                    if (! $failoverPlaylist) {
+                        continue;
+                    }
+
+                    if ($failoverPlaylist->available_streams === 0) {
+                        $playlist = $failoverPlaylist;
+                        $episode = $failoverEpisode;
+                        $actualEpisode = $failoverEpisode;
+                        $id = $episode->id;
+                        break;
+                    }
+
+                    $failoverActiveStreams = self::getActiveStreamsCountByMetadata('playlist_uuid', $failoverPlaylist->uuid);
+                    if ($failoverActiveStreams < $failoverPlaylist->available_streams) {
+                        $playlist = $failoverPlaylist;
+                        $episode = $failoverEpisode;
+                        $actualEpisode = $failoverEpisode;
+                        $id = $episode->id;
+                        break;
                     }
                 }
 
-                // If still at capacity (either setting disabled or stop failed), try episode failovers.
-                if ($activeStreams >= $playlist->available_streams) {
-                    $cachedFailoverEpisodes = $requestedEpisode->failoverEpisodes()->with('playlist')->get();
-                    foreach ($cachedFailoverEpisodes as $failoverEpisode) {
-                        $failoverPlaylist = $failoverEpisode->getEffectivePlaylist();
-                        if (! $failoverPlaylist) {
-                            continue;
-                        }
+                if ($actualEpisode->id === $originalEpisodeId) {
+                    Log::debug('Episode stream request denied - all playlists at capacity', [
+                        'episode_id' => $originalEpisodeId,
+                        'denied_playlist' => $deniedPlaylist->uuid,
+                        'limit' => $deniedPlaylist->available_streams,
+                        'active' => $activeStreams,
+                    ]);
 
-                        if ($failoverPlaylist->available_streams === 0) {
-                            $playlist = $failoverPlaylist;
-                            $episode = $failoverEpisode;
-                            $actualEpisode = $failoverEpisode;
-                            $id = $episode->id;
-                            break;
-                        }
+                    abort(503, 'All playlists have reached their maximum stream limit. Please try again later.');
+                }
 
-                        $failoverActiveStreams = self::getActiveStreamsCountByMetadata('playlist_uuid', $failoverPlaylist->uuid);
-                        if ($failoverActiveStreams < $failoverPlaylist->available_streams) {
-                            $playlist = $failoverPlaylist;
-                            $episode = $failoverEpisode;
-                            $actualEpisode = $failoverEpisode;
-                            $id = $episode->id;
-                            break;
-                        }
-                    }
-
-                    if ($actualEpisode->id === $originalEpisodeId) {
-                        Log::debug('Episode stream request denied - all playlists at capacity', [
-                            'episode_id' => $originalEpisodeId,
-                            'playlist' => $playlist->uuid,
-                            'limit' => $playlist->available_streams,
-                            'active' => $activeStreams,
-                        ]);
-
-                        abort(503, 'All playlists have reached their maximum stream limit. Please try again later.');
-                    }
-
-                    $profileSourcePlaylist = null;
-                    if ($playlist instanceof Playlist && $playlist->profiles_enabled) {
-                        $profileSourcePlaylist = $playlist;
-                    } elseif ($episode->playlist instanceof Playlist && $episode->playlist->profiles_enabled) {
-                        $profileSourcePlaylist = $episode->playlist;
-                    }
+                $profileSourcePlaylist = null;
+                if ($playlist instanceof Playlist && $playlist->profiles_enabled) {
+                    $profileSourcePlaylist = $playlist;
+                } elseif ($episode->playlist instanceof Playlist && $episode->playlist->profiles_enabled) {
+                    $profileSourcePlaylist = $episode->playlist;
                 }
             }
         }
@@ -1917,6 +2003,7 @@ class M3uProxyService
                 'use_sticky_session' => $playlist->use_sticky_session ?? false,
                 'original_episode_id' => $originalEpisodeId,           // Enables findExistingPooledStream reuse
                 'original_playlist_uuid' => $originalPlaylistUuid,
+                'source_playlist_uuid' => $actualEpisode->playlist instanceof Playlist ? $actualEpisode->playlist->uuid : null,  // For wrapper-aware capacity accounting
                 'is_failover' => $actualEpisode->id !== $originalEpisodeId,
             ];
 
@@ -1964,6 +2051,7 @@ class M3uProxyService
                 'use_sticky_session' => $playlist->use_sticky_session ?? false,
                 'original_episode_id' => $originalEpisodeId,           // Enables findExistingPooledStream reuse
                 'original_playlist_uuid' => $originalPlaylistUuid,
+                'source_playlist_uuid' => $actualEpisode->playlist instanceof Playlist ? $actualEpisode->playlist->uuid : null,  // For wrapper-aware capacity accounting
                 'is_failover' => $actualEpisode->id !== $originalEpisodeId,
             ];
 

--- a/lang/de.json
+++ b/lang/de.json
@@ -3167,7 +3167,7 @@
     "Name of the variable to send as GET/POST variable to your webhook URL.": "Name der Variablen, die als GET/POST-Variable an Ihre Webhook-URL gesendet werden soll.",
     "Name override": "Name override",
     "Naming": "Benennung",
-    "Navigation Menu": "Navigationsmenü",
+    "Navigation": "Navigation",
     "Navigation position": "Navigationsposition",
     "Navigation restored to Default": "Navigation auf Standard zurückgesetzt",
     "Navigation set to Simplified Default": "Navigation auf Vereinfachten Standard gesetzt",

--- a/lang/en.json
+++ b/lang/en.json
@@ -4273,7 +4273,7 @@
     "Name of the variable to send as GET/POST variable to your webhook URL.": "Name of the variable to send as GET/POST variable to your webhook URL.",
     "Name override": "Name override",
     "Naming": "Naming",
-    "Navigation Menu": "Navigation Menu",
+    "Navigation": "Navigation",
     "Navigation position": "Navigation position",
     "Navigation restored to Default": "Navigation restored to Default",
     "Navigation set to Simplified Default": "Navigation set to Simplified Default",

--- a/lang/es.json
+++ b/lang/es.json
@@ -3167,7 +3167,7 @@
     "Name of the variable to send as GET/POST variable to your webhook URL.": "Nombre de la variable que se enviará como variable GET/POST a la URL de su webhook.",
     "Name override": "Name override",
     "Naming": "Nomenclatura",
-    "Navigation Menu": "Menú de navegación",
+    "Navigation": "Navegación",
     "Navigation position": "Posición de navegación",
     "Navigation restored to Default": "Navegación restaurada a los valores predeterminados",
     "Navigation set to Simplified Default": "Navegación configurada en Predeterminado simplificado",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -3167,7 +3167,7 @@
     "Name of the variable to send as GET/POST variable to your webhook URL.": "Nom de la variable à envoyer en tant que variable GET/POST à ​​l'URL de votre webhook.",
     "Name override": "Name override",
     "Naming": "Nommage",
-    "Navigation Menu": "Menu de navigation",
+    "Navigation": "Navigation",
     "Navigation position": "Position de navigation",
     "Navigation restored to Default": "Navigation restaurée par défaut",
     "Navigation set to Simplified Default": "Navigation définie sur Par défaut simplifié",

--- a/lang/zh_CN.json
+++ b/lang/zh_CN.json
@@ -3167,7 +3167,7 @@
     "Name of the variable to send as GET/POST variable to your webhook URL.": "作为 GET/POST 变量发送到 Webhook URL 的变量名称。",
     "Name override": "Name override",
     "Naming": "命名",
-    "Navigation Menu": "导航菜单",
+    "Navigation": "导航",
     "Navigation position": "导航位置",
     "Navigation restored to Default": "导航已恢复为默认设置",
     "Navigation set to Simplified Default": "导航已设置为简化默认",

--- a/tests/Feature/DirectStreamPoolReuseTest.php
+++ b/tests/Feature/DirectStreamPoolReuseTest.php
@@ -361,14 +361,19 @@ test('getEpisodeUrl uses first available episode failover when primary playlist 
         'sort' => 1,
     ]);
 
-    Http::fake(function ($request) use ($playlistA) {
+    Http::fake(function ($request) use ($playlistA, $master) {
         if (str_contains($request->url(), '/streams/by-metadata')) {
+            $field = $request['field'] ?? null;
             $value = $request['value'] ?? null;
+            $isAtCapacity = $field === 'playlist_uuid' && $value === $playlistA->uuid;
 
             return Http::response([
-                'matching_streams' => [],
-                'total_matching' => $value === $playlistA->uuid ? 1 : 0,
-                'total_clients' => $value === $playlistA->uuid ? 1 : 0,
+                'matching_streams' => $isAtCapacity ? [[
+                    'stream_id' => 'existing-episode-stream',
+                    'metadata' => ['type' => 'episode', 'episode_id' => (string) $master->id],
+                ]] : [],
+                'total_matching' => $isAtCapacity ? 1 : 0,
+                'total_clients' => $isAtCapacity ? 1 : 0,
             ]);
         }
 

--- a/tests/Feature/M3uProxyWrapperCapacityTest.php
+++ b/tests/Feature/M3uProxyWrapperCapacityTest.php
@@ -24,8 +24,10 @@ use App\Enums\DvrRecordingStatus;
 use App\Models\Channel;
 use App\Models\DvrRecording;
 use App\Models\DvrSetting;
+use App\Models\Episode;
 use App\Models\MergedPlaylist;
 use App\Models\Playlist;
+use App\Models\Series;
 use App\Models\User;
 use App\Services\M3uProxyService;
 use App\Settings\GeneralSettings;
@@ -187,4 +189,67 @@ test('an active DVR recording counts toward capacity and is never evicted — a 
 
     expect($deletedStreamId)->toBe('live-a')
         ->and($url)->toBeString()->not->toBeEmpty();
+});
+
+test('the source playlist cap is enforced through an unlimited merged wrapper for episode streaming', function () {
+    $source = Playlist::factory()->for($this->user)->create([
+        'enable_proxy' => true,
+        'available_streams' => 1,
+    ]);
+    $merged = MergedPlaylist::factory()->for($this->user)->create(['available_streams' => 0]);
+    $merged->playlists()->attach($source->id);
+
+    $series = Series::factory()->for($this->user)->for($source)->create();
+    $episodeA = Episode::factory()->for($this->user)->for($source)->for($series)->create(['url' => 'http://example.com/a.mkv']);
+    $episodeB = Episode::factory()->for($this->user)->for($source)->for($series)->create(['url' => 'http://example.com/b.mkv']);
+
+    // Episode A is already streaming through the wrapper — tagged with
+    // source_playlist_uuid = the source playlist's uuid, not playlist_uuid.
+    Http::fake([
+        '*/streams/by-metadata*' => function ($request) use ($source, $episodeA) {
+            parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
+            if (($query['field'] ?? null) === 'source_playlist_uuid' && ($query['value'] ?? null) === $source->uuid) {
+                return Http::response([
+                    'matching_streams' => [['stream_id' => 'live-a', 'metadata' => ['type' => 'episode', 'episode_id' => (string) $episodeA->id]]],
+                    'total_matching' => 1,
+                ]);
+            }
+
+            return Http::response(['matching_streams' => [], 'total_matching' => 0]);
+        },
+    ]);
+
+    expect(fn () => app(M3uProxyService::class)->getEpisodeUrl($merged, $episodeB))
+        ->toThrow(HttpException::class);
+});
+
+test('the wrapper playlist cap is enforced for episode streaming when its source playlist is unlimited', function () {
+    $source = Playlist::factory()->for($this->user)->create([
+        'enable_proxy' => true,
+        'available_streams' => 0,
+    ]);
+    $merged = MergedPlaylist::factory()->for($this->user)->create(['available_streams' => 1]);
+    $merged->playlists()->attach($source->id);
+
+    $series = Series::factory()->for($this->user)->for($source)->create();
+    $episodeA = Episode::factory()->for($this->user)->for($source)->for($series)->create(['url' => 'http://example.com/a.mkv']);
+    $episodeB = Episode::factory()->for($this->user)->for($source)->for($series)->create(['url' => 'http://example.com/b.mkv']);
+
+    // Episode A is already streaming directly through the wrapper.
+    Http::fake([
+        '*/streams/by-metadata*' => function ($request) use ($merged, $episodeA) {
+            parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
+            if (($query['field'] ?? null) === 'playlist_uuid' && ($query['value'] ?? null) === $merged->uuid) {
+                return Http::response([
+                    'matching_streams' => [['stream_id' => 'live-a', 'metadata' => ['type' => 'episode', 'episode_id' => (string) $episodeA->id]]],
+                    'total_matching' => 1,
+                ]);
+            }
+
+            return Http::response(['matching_streams' => [], 'total_matching' => 0]);
+        },
+    ]);
+
+    expect(fn () => app(M3uProxyService::class)->getEpisodeUrl($merged, $episodeB))
+        ->toThrow(HttpException::class);
 });

--- a/tests/Feature/M3uProxyWrapperCapacityTest.php
+++ b/tests/Feature/M3uProxyWrapperCapacityTest.php
@@ -1,0 +1,190 @@
+<?php
+
+/**
+ * Regression coverage for wrapper-aware DVR capacity accounting in
+ * M3uProxyService::getChannelUrl().
+ *
+ * Before this fix, only ONE playlist's available_streams was ever enforced —
+ * whichever of the wrapper (CustomPlaylist/MergedPlaylist) or its source
+ * Playlist happened to be picked as authoritative — so the other one's
+ * configured limit was silently dropped. It also didn't count active DVR
+ * recordings against the limit, and "stop oldest on limit" eviction had no
+ * way to avoid stopping a recording-backed stream.
+ *
+ * Locks in:
+ *   1. The source Playlist's own cap (e.g. a hardware tuner pool) is enforced
+ *      even when accessed through an unlimited wrapper.
+ *   2. The wrapper's own cap is enforced even when its source Playlist is
+ *      unlimited.
+ *   3. An active DVR recording counts toward the limit and is never evicted
+ *      by "stop oldest on limit" — a live viewer stream is evicted instead.
+ */
+
+use App\Enums\DvrRecordingStatus;
+use App\Models\Channel;
+use App\Models\DvrRecording;
+use App\Models\DvrSetting;
+use App\Models\MergedPlaylist;
+use App\Models\Playlist;
+use App\Models\User;
+use App\Services\M3uProxyService;
+use App\Settings\GeneralSettings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+    $this->user = User::factory()->create();
+
+    config([
+        'proxy.m3u_proxy_host' => 'http://localhost',
+        'proxy.m3u_proxy_port' => 8765,
+        'proxy.m3u_proxy_token' => 'test-token',
+        'cache.default' => 'array',
+    ]);
+});
+
+test('the source playlist cap is enforced through an unlimited merged wrapper', function () {
+    $source = Playlist::factory()->for($this->user)->create([
+        'enable_proxy' => true,
+        'available_streams' => 1,
+    ]);
+    $merged = MergedPlaylist::factory()->for($this->user)->create(['available_streams' => 0]);
+    $merged->playlists()->attach($source->id);
+
+    $channelA = Channel::factory()->for($source)->create(['enabled' => true, 'url' => 'http://example.com/a']);
+    $channelB = Channel::factory()->for($source)->create(['enabled' => true, 'url' => 'http://example.com/b']);
+
+    // Channel A is already streaming through the wrapper — tagged with
+    // source_playlist_uuid = the source playlist's uuid, not playlist_uuid.
+    Http::fake([
+        '*/streams/by-metadata*' => function ($request) use ($source, $channelA) {
+            parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
+            if (($query['field'] ?? null) === 'source_playlist_uuid' && ($query['value'] ?? null) === $source->uuid) {
+                return Http::response([
+                    'matching_streams' => [['stream_id' => 'live-a', 'metadata' => ['channel_id' => (string) $channelA->id]]],
+                    'total_matching' => 1,
+                ]);
+            }
+
+            return Http::response(['matching_streams' => [], 'total_matching' => 0]);
+        },
+    ]);
+
+    expect(fn () => app(M3uProxyService::class)->getChannelUrl($merged, $channelB))
+        ->toThrow(HttpException::class);
+});
+
+test('the wrapper playlist cap is enforced when its source playlist is unlimited', function () {
+    $source = Playlist::factory()->for($this->user)->create([
+        'enable_proxy' => true,
+        'available_streams' => 0,
+    ]);
+    $merged = MergedPlaylist::factory()->for($this->user)->create(['available_streams' => 1]);
+    $merged->playlists()->attach($source->id);
+
+    $channelA = Channel::factory()->for($source)->create(['enabled' => true, 'url' => 'http://example.com/a']);
+    $channelB = Channel::factory()->for($source)->create(['enabled' => true, 'url' => 'http://example.com/b']);
+
+    // Channel A is already streaming directly through the wrapper.
+    Http::fake([
+        '*/streams/by-metadata*' => function ($request) use ($merged, $channelA) {
+            parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
+            if (($query['field'] ?? null) === 'playlist_uuid' && ($query['value'] ?? null) === $merged->uuid) {
+                return Http::response([
+                    'matching_streams' => [['stream_id' => 'live-a', 'metadata' => ['channel_id' => (string) $channelA->id]]],
+                    'total_matching' => 1,
+                ]);
+            }
+
+            return Http::response(['matching_streams' => [], 'total_matching' => 0]);
+        },
+    ]);
+
+    expect(fn () => app(M3uProxyService::class)->getChannelUrl($merged, $channelB))
+        ->toThrow(HttpException::class);
+});
+
+test('an active DVR recording counts toward capacity and is never evicted — a live viewer is evicted instead', function () {
+    // Mock GeneralSettings so "stop oldest on limit" is enabled without DB persistence.
+    $settings = Mockery::mock(GeneralSettings::class)->makePartial();
+    $settings->proxy_stop_oldest_on_limit = true;
+    app()->instance(GeneralSettings::class, $settings);
+
+    $playlist = Playlist::factory()->for($this->user)->create([
+        'enable_proxy' => true,
+        'available_streams' => 2,
+    ]);
+    $dvrSetting = DvrSetting::factory()->enabled()->for($this->user)->for($playlist)->create();
+
+    $channelLive = Channel::factory()->for($playlist)->create(['enabled' => true, 'url' => 'http://example.com/live']);
+    $channelRecording = Channel::factory()->for($playlist)->create(['enabled' => true, 'url' => 'http://example.com/rec']);
+    $channelNew = Channel::factory()->for($playlist)->create(['enabled' => true, 'url' => 'http://example.com/new']);
+
+    DvrRecording::factory()
+        ->for($dvrSetting, 'dvrSetting')
+        ->for($this->user)
+        ->for($channelRecording)
+        ->create(['status' => DvrRecordingStatus::Recording]);
+
+    $deletedStreamId = null;
+
+    Http::fake([
+        '*/streams/by-metadata*' => function ($request) use ($playlist, $channelLive, &$deletedStreamId) {
+            parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
+            if (($query['field'] ?? null) === 'playlist_uuid' && ($query['value'] ?? null) === $playlist->uuid) {
+                return Http::response([
+                    'matching_streams' => $deletedStreamId ? [] : [['stream_id' => 'live-a', 'metadata' => ['channel_id' => (string) $channelLive->id]]],
+                    'total_matching' => $deletedStreamId ? 0 : 1,
+                ]);
+            }
+
+            return Http::response(['matching_streams' => [], 'total_matching' => 0]);
+        },
+        '*/streams/*' => function ($request) use (&$deletedStreamId) {
+            if ($request->method() === 'DELETE') {
+                $deletedStreamId = (string) collect(explode('/', (string) parse_url($request->url(), PHP_URL_PATH)))->last();
+
+                return Http::response([], 200);
+            }
+
+            return Http::response([], 200);
+        },
+        '*/streams' => function ($request) use ($playlist, $channelLive, $channelRecording) {
+            if ($request->method() === 'GET') {
+                return Http::response([
+                    'streams' => [
+                        [
+                            'stream_id' => 'live-a',
+                            'created_at' => now()->subMinutes(5)->toIso8601String(),
+                            'is_active' => true,
+                            'client_count' => 1,
+                            'metadata' => ['channel_id' => (string) $channelLive->id, 'playlist_uuid' => $playlist->uuid],
+                        ],
+                        // A recording-backed stream — must never be picked as an eviction candidate.
+                        [
+                            'stream_id' => 'recording-stream',
+                            'created_at' => now()->subMinutes(30)->toIso8601String(),
+                            'is_active' => true,
+                            'client_count' => 1,
+                            'metadata' => ['channel_id' => (string) $channelRecording->id, 'playlist_uuid' => $playlist->uuid],
+                        ],
+                    ],
+                    'total' => 2,
+                ]);
+            }
+
+            // POST create
+            return Http::response(['stream_id' => 'new-stream-id']);
+        },
+    ]);
+
+    $url = app(M3uProxyService::class)->getChannelUrl($playlist, $channelNew);
+
+    expect($deletedStreamId)->toBe('live-a')
+        ->and($url)->toBeString()->not->toBeEmpty();
+});

--- a/tests/Feature/XtreamCustomPlaylistDvrCapabilitiesTest.php
+++ b/tests/Feature/XtreamCustomPlaylistDvrCapabilitiesTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * Regression coverage for the DVR endpoints that read/write via
+ * `resolveDvrSettingIds()` / `resolveDvrSettingForWrite()` when accessed through a
+ * CustomPlaylist wrapping a channel whose DvrSetting lives on the source Playlist.
+ *
+ * XtreamCustomPlaylistDvrTest.php already covers get/cancel/delete recordings.
+ * This file covers the remaining endpoints that had the same
+ * `$playlist->dvrSetting` bug: storage, series-rule list/create/update/delete,
+ * and EPG show search.
+ */
+
+use App\Enums\DvrRuleType;
+use App\Models\Channel;
+use App\Models\CustomPlaylist;
+use App\Models\DvrRecordingRule;
+use App\Models\DvrSetting;
+use App\Models\Epg;
+use App\Models\EpgChannel;
+use App\Models\EpgProgramme;
+use App\Models\Group;
+use App\Models\Playlist;
+use App\Models\User;
+use App\Services\M3uProxyService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::factory()->for($this->user)->create();
+    $this->group = Group::factory()->for($this->user)->create();
+    $this->channel = Channel::factory()
+        ->for($this->playlist)
+        ->for($this->group)
+        ->create(['enabled' => true, 'title_custom' => 'News 24']);
+
+    $this->setting = DvrSetting::factory()
+        ->enabled()
+        ->for($this->user)
+        ->for($this->playlist)
+        ->create();
+
+    $this->customPlaylist = CustomPlaylist::factory()->for($this->user)->create();
+    $this->customPlaylist->channels()->attach($this->channel->id, ['sort' => 0]);
+
+    $proxy = Mockery::mock(M3uProxyService::class);
+    $proxy->shouldReceive('stopDvrBroadcast')->andReturn(true);
+    $proxy->shouldReceive('cleanupDvrBroadcast')->andReturn(true);
+    app()->instance(M3uProxyService::class, $proxy);
+});
+
+function customPlaylistDvrCapUrl(string $username, string $password, string $action): string
+{
+    return route('xtream.api.player').'?'.http_build_query([
+        'username' => $username,
+        'password' => $password,
+        'action' => $action,
+    ]);
+}
+
+it('reports DVR storage stats through a CustomPlaylist wrapping the source channel', function () {
+    $response = $this->postJson(
+        customPlaylistDvrCapUrl($this->user->name, $this->customPlaylist->uuid, 'get_dvr_storage')
+    )->assertOk();
+
+    expect($response->json('scope'))->toBe('account');
+});
+
+it('lists a series rule filed under the source playlist through a CustomPlaylist', function () {
+    $rule = DvrRecordingRule::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->create(['type' => DvrRuleType::Series, 'enabled' => true, 'series_title' => 'Evening News']);
+
+    $response = $this->postJson(
+        customPlaylistDvrCapUrl($this->user->name, $this->customPlaylist->uuid, 'list_dvr_series_rules')
+    )->assertOk();
+
+    $ids = collect($response->json())->pluck('id');
+    expect($ids)->toContain($rule->id);
+});
+
+it('creates a series rule through a CustomPlaylist, filed under the channel source playlist DvrSetting', function () {
+    $response = $this->postJson(
+        customPlaylistDvrCapUrl($this->user->name, $this->customPlaylist->uuid, 'create_dvr_series_rule'),
+        ['channel_id' => (string) $this->channel->id, 'title' => 'Morning Show']
+    )->assertOk()->assertJson(['success' => true]);
+
+    $rule = DvrRecordingRule::find($response->json('rule_id'));
+    expect($rule)->not->toBeNull()
+        ->and($rule->dvr_setting_id)->toBe($this->setting->id);
+});
+
+it('updates a series rule filed under the source playlist through a CustomPlaylist', function () {
+    $rule = DvrRecordingRule::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->create(['type' => DvrRuleType::Series, 'enabled' => true, 'series_title' => 'Evening News', 'priority' => 50]);
+
+    $this->postJson(
+        customPlaylistDvrCapUrl($this->user->name, $this->customPlaylist->uuid, 'update_dvr_series_rule'),
+        ['rule_id' => $rule->id, 'priority' => 90]
+    )->assertOk()->assertJson(['success' => true]);
+
+    expect($rule->fresh()->priority)->toBe(90);
+});
+
+it('deletes a series rule filed under the source playlist through a CustomPlaylist', function () {
+    $rule = DvrRecordingRule::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->create(['type' => DvrRuleType::Series, 'enabled' => true, 'series_title' => 'Evening News']);
+
+    $this->postJson(
+        customPlaylistDvrCapUrl($this->user->name, $this->customPlaylist->uuid, 'delete_dvr_series_rule'),
+        ['rule_id' => $rule->id]
+    )->assertOk()->assertJson(['success' => true]);
+
+    expect(DvrRecordingRule::find($rule->id))->toBeNull();
+});
+
+it('searches EPG shows through a CustomPlaylist wrapping the source channel', function () {
+    $epg = Epg::factory()->for($this->user)->create();
+    $epgChannel = EpgChannel::factory()->for($this->user)->for($epg)->create(['channel_id' => 'epg-1']);
+    $this->channel->update(['epg_channel_id' => $epgChannel->id]);
+
+    EpgProgramme::factory()->for($epg)->create([
+        'epg_channel_id' => 'epg-1',
+        'title' => 'Breaking News Tonight',
+        'start_time' => now()->addHour(),
+        'end_time' => now()->addHours(2),
+    ]);
+
+    $response = $this->postJson(
+        customPlaylistDvrCapUrl($this->user->name, $this->customPlaylist->uuid, 'search_epg_shows'),
+        ['q' => 'Breaking News']
+    )->assertOk();
+
+    $titles = collect($response->json())->pluck('display_title');
+    expect($titles)->toContain('Breaking News Tonight');
+});

--- a/tests/Feature/XtreamCustomPlaylistDvrTest.php
+++ b/tests/Feature/XtreamCustomPlaylistDvrTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * Regression coverage for `resolveDvrSettingIds()` handling CustomPlaylist.
+ *
+ * Before this fix, `get_dvr_recordings` / `get_dvr_recording` / `cancel_dvr_recording` /
+ * `delete_dvr_recording` read `$playlist->dvrSetting` directly. A CustomPlaylist has no
+ * DvrSetting of its own when the recording was actually scheduled against its channels'
+ * real source Playlist — so listing/cancelling/deleting through the CustomPlaylist a guest
+ * actually authenticated against always came back empty/404, even though the same
+ * recording was fully visible and manageable through the source Playlist directly.
+ *
+ * Locks in:
+ *   1. A recording filed under the source Playlist's DvrSetting is visible via
+ *      get_dvr_recordings/get_dvr_recording when authenticated against a CustomPlaylist
+ *      whose channels include that recording's channel.
+ *   2. cancel_dvr_recording and delete_dvr_recording work the same way through the
+ *      CustomPlaylist.
+ *   3. A CustomPlaylist with no channels from that source Playlist sees nothing.
+ */
+
+use App\Enums\DvrRecordingStatus;
+use App\Models\Channel;
+use App\Models\CustomPlaylist;
+use App\Models\DvrRecording;
+use App\Models\DvrSetting;
+use App\Models\Group;
+use App\Models\Playlist;
+use App\Models\User;
+use App\Services\M3uProxyService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::factory()->for($this->user)->create();
+    $this->group = Group::factory()->for($this->user)->create();
+    $this->channel = Channel::factory()
+        ->for($this->playlist)
+        ->for($this->group)
+        ->create(['enabled' => true, 'title_custom' => 'News 24']);
+
+    $this->setting = DvrSetting::factory()
+        ->enabled()
+        ->for($this->user)
+        ->for($this->playlist)
+        ->create();
+
+    $this->customPlaylist = CustomPlaylist::factory()->for($this->user)->create();
+    $this->customPlaylist->channels()->attach($this->channel->id, ['sort' => 0]);
+
+    $proxy = Mockery::mock(M3uProxyService::class);
+    $proxy->shouldReceive('stopDvrBroadcast')->andReturn(true);
+    $proxy->shouldReceive('cleanupDvrBroadcast')->andReturn(true);
+    app()->instance(M3uProxyService::class, $proxy);
+});
+
+function customPlaylistDvrActionUrl(string $username, string $password, string $action): string
+{
+    return route('xtream.api.player').'?'.http_build_query([
+        'username' => $username,
+        'password' => $password,
+        'action' => $action,
+    ]);
+}
+
+it('lists a recording filed under the source playlist through a CustomPlaylist wrapping that channel', function () {
+    $recording = DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->create(['status' => DvrRecordingStatus::Scheduled]);
+
+    $response = $this->postJson(
+        customPlaylistDvrActionUrl($this->user->name, $this->customPlaylist->uuid, 'get_dvr_recordings')
+    )->assertOk();
+
+    $uuids = collect($response->json())->pluck('uuid');
+    expect($uuids)->toContain($recording->uuid);
+});
+
+it('fetches a single recording via get_dvr_recording through a CustomPlaylist', function () {
+    $recording = DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->create(['status' => DvrRecordingStatus::Scheduled]);
+
+    $this->postJson(
+        customPlaylistDvrActionUrl($this->user->name, $this->customPlaylist->uuid, 'get_dvr_recording'),
+        ['recording_id' => $recording->uuid]
+    )->assertOk()->assertJsonPath('uuid', $recording->uuid);
+});
+
+it('cancels a recording through a CustomPlaylist wrapping the source channel', function () {
+    $recording = DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->create(['status' => DvrRecordingStatus::Scheduled, 'proxy_network_id' => null]);
+
+    $this->postJson(
+        customPlaylistDvrActionUrl($this->user->name, $this->customPlaylist->uuid, 'cancel_dvr_recording'),
+        ['recording_id' => $recording->uuid]
+    )->assertOk()->assertJson(['success' => true]);
+
+    expect($recording->fresh()->status)->toBe(DvrRecordingStatus::Cancelled);
+});
+
+it('deletes a completed recording through a CustomPlaylist wrapping the source channel', function () {
+    $recording = DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->create(['status' => DvrRecordingStatus::Completed]);
+
+    $this->postJson(
+        customPlaylistDvrActionUrl($this->user->name, $this->customPlaylist->uuid, 'delete_dvr_recording'),
+        ['recording_id' => $recording->uuid]
+    )->assertOk()->assertJson(['success' => true]);
+
+    expect(DvrRecording::find($recording->id))->toBeNull();
+});
+
+it('denies DVR access through a CustomPlaylist with no channels from any DVR-enabled source playlist', function () {
+    $otherCustomPlaylist = CustomPlaylist::factory()->for($this->user)->create();
+
+    DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->create(['status' => DvrRecordingStatus::Scheduled]);
+
+    // No source-playlist channels means resolveDvrSettingIds() finds nothing to grant
+    // capability against, so this is a 403 (DVR access denied), not an empty 200 list —
+    // the other playlist's recording must never be reachable here either way.
+    $this->postJson(
+        customPlaylistDvrActionUrl($this->user->name, $otherCustomPlaylist->uuid, 'get_dvr_recordings')
+    )->assertStatus(403)->assertJson(['error' => 'DVR access denied']);
+});


### PR DESCRIPTION
DVR capacity accounting only enforced one of the wrapper playlist's or its source playlist's available_streams limit, silently dropping the other - now both are checked, DVR recordings count toward the limit, and "stop oldest on limit" eviction never targets a recording-backed stream.

resolveDvrSettingIds() (and the DVR capability gate) now resolves through a CustomPlaylist's channels, not just a MergedPlaylist's pivot table, so DVR recordings scheduled against the source playlist stay visible and cancellable when listed through a CustomPlaylist wrapping that channel.