### PR TITLE
fix: Extension for M3U and HDHR output not using proxy format when enabled

### DIFF
--- a/app/Http/Controllers/PlaylistGenerateController.php
+++ b/app/Http/Controllers/PlaylistGenerateController.php
@@ -98,8 +98,10 @@ class PlaylistGenerateController extends Controller
         // Get the base URL
         $baseUrl = ProxyFacade::getBaseUrl();
 
-        // Pre-compute MediaFlow stream URL rewrite flag (checked once, used per channel)
-        $mfRewriteEnabled = ! $proxyEnabled && PlaylistFacade::mediaFlowProxyEnabled()
+        // Pre-compute the global MediaFlow settings (checked once); whether it actually
+        // applies is decided per-channel below, since the proxy can be forced on for a
+        // single channel (or its source playlist) even when the playlist-level toggle is off.
+        $mediaFlowRewriteStreamUrls = PlaylistFacade::mediaFlowProxyEnabled()
             && (PlaylistFacade::getMediaFlowSettings()['mediaflow_proxy_rewrite_stream_urls'] ?? false);
 
         // Build the channel query
@@ -108,7 +110,7 @@ class PlaylistGenerateController extends Controller
 
         // Get all active channels
         return response()->stream(
-            function () use ($cursor, $baseUrl, $playlist, $proxyEnabled, $logoProxyEnabled, $type, $tvgTypeoutputEnabled, $usedAuth, $mfRewriteEnabled) {
+            function () use ($cursor, $baseUrl, $playlist, $proxyEnabled, $logoProxyEnabled, $type, $tvgTypeoutputEnabled, $usedAuth, $mediaFlowRewriteStreamUrls) {
                 // Set the auth details
                 if ($usedAuth) {
                     $username = urlencode($usedAuth->username);
@@ -123,7 +125,31 @@ class PlaylistGenerateController extends Controller
                 echo "#EXTM3U x-tvg-url=\"$epgUrl\" \n";
                 $channelNumber = ($playlist->auto_channel_increment || $playlist->force_channel_numbering) ? $playlist->channel_start - 1 : 0;
                 $idChannelBy = $playlist->id_channel_by;
+                // Memoized by playlist_id so a batch of channels sharing the same source
+                // playlist (the common case) only resolves it once rather than per row.
+                $sourcePlaylistCache = [];
                 foreach ($cursor as $channel) {
+                    // Resolve the channel's own source playlist (may differ from the
+                    // requested $playlist for merged/custom playlists/aliases) so we can
+                    // check its proxy/output settings without an N+1 query per channel.
+                    $sourcePlaylistId = $channel->playlist_id;
+                    if ($sourcePlaylistId !== null) {
+                        if (! array_key_exists($sourcePlaylistId, $sourcePlaylistCache)) {
+                            $sourcePlaylistCache[$sourcePlaylistId] = Playlist::find($sourcePlaylistId, ['id', 'xtream', 'enable_proxy', 'profiles_enabled', 'xtream_config']);
+                        }
+                        $channelSourcePlaylist = $sourcePlaylistCache[$sourcePlaylistId];
+                    } else {
+                        $channelSourcePlaylist = null;
+                    }
+
+                    // A channel can force the proxy path even when the playlist-level toggle
+                    // is off: its own per-channel override, or its source playlist pooling
+                    // provider profiles (profile selection/pool distribution only happens on
+                    // the proxy path). Mirrors the `needsProxy` check in
+                    // XtreamStreamController::handleLive()/handleVod().
+                    $channelProxyEnabled = $playlist->user->canUseProxy()
+                        && ($proxyEnabled || $channel->enable_proxy || ($channelSourcePlaylist->profiles_enabled ?? false));
+                    $channelMfRewriteEnabled = ! $channelProxyEnabled && $mediaFlowRewriteStreamUrls;
                     // Get the title and name
                     $title = $channel->title_custom ?? $channel->title;
                     $name = $channel->name_custom ?? $channel->name;
@@ -185,9 +211,8 @@ class PlaylistGenerateController extends Controller
                     $filename = parse_url($url, PHP_URL_PATH);
                     $extension = pathinfo($filename, PATHINFO_EXTENSION);
                     if (empty($extension)) {
-                        $sourcePlaylist = $channel->getEffectivePlaylist();
-                        if ($sourcePlaylist?->xtream) {
-                            $extension = $sourcePlaylist->xtream_config['output'] ?? 'ts'; // Default to 'ts' if not set
+                        if ($channelSourcePlaylist?->xtream) {
+                            $extension = $channelSourcePlaylist->xtream_config['output'] ?? 'ts'; // Default to 'ts' if not set
                         }
                     }
 
@@ -205,9 +230,17 @@ class PlaylistGenerateController extends Controller
                         if ($channel->is_vod) {
                             $urlPath = 'movie';
                             $extension = $channel->container_extension ?? 'mkv';
+                        } elseif ($channelProxyEnabled) {
+                            // The proxy may transcode the stream, so advertise the configured
+                            // output format instead of the raw provider extension - mirrors the
+                            // allowed_output_formats resolution in XtreamApiController::__invoke().
+                            $proxyOutput = $channelSourcePlaylist->xtream_config['output']
+                                ?? $playlist->xtream_config['output']
+                                ?? 'ts';
+                            $extension = $proxyOutput === 'hls' ? 'm3u8' : $proxyOutput;
                         }
                         $url = $baseUrl."/{$urlPath}/{$username}/{$password}/".$channel->id.'.'.$extension;
-                    } elseif ($mfRewriteEnabled) {
+                    } elseif ($channelMfRewriteEnabled) {
                         // Raw URL mode: wrap the provider URL through MediaFlow Proxy
                         $url = PlaylistFacade::buildMediaFlowStreamUrl($url);
                     }
@@ -230,7 +263,7 @@ class PlaylistGenerateController extends Controller
                         // m3u-editor rather than going directly to the provider.
                         // This also ensures catchup works for Xtream-imported channels that have
                         // tv_archive=1 but no catchup_source URL template stored.
-                        if (($proxyEnabled || $useInternalXtreamFormat) && $channel->catchup) {
+                        if (($channelProxyEnabled || $useInternalXtreamFormat) && $channel->catchup) {
                             $catchupExt = $extension ?: 'ts';
                             $catchupSource = "{$baseUrl}/timeshift/{$username}/{$password}/{duration}/{start}/{$channel->id}.{$catchupExt}";
                             $extInf .= " catchup-source=\"{$catchupSource}\"";
@@ -317,7 +350,7 @@ class PlaylistGenerateController extends Controller
                             if (! ((config('app.disable_m3u_xtream_format') ?? false) || $playlist->disable_m3u_xtream_format) || $proxyEnabled) {
                                 $containerExtension = $episode->container_extension ?? 'mp4';
                                 $url = $baseUrl."/series/{$username}/{$password}/".$episode->id.".{$containerExtension}";
-                            } elseif ($mfRewriteEnabled) {
+                            } elseif (! $proxyEnabled && $mediaFlowRewriteStreamUrls) {
                                 // Raw URL mode: wrap the provider URL through MediaFlow Proxy
                                 $url = PlaylistFacade::buildMediaFlowStreamUrl($url);
                             }
@@ -541,18 +574,45 @@ class PlaylistGenerateController extends Controller
             $proxyEnabled = $playlist->enable_proxy;
         }
 
-        // Pre-compute MediaFlow stream URL rewrite flag (checked once, used per channel)
-        $mfRewriteEnabled = ! $proxyEnabled && PlaylistFacade::mediaFlowProxyEnabled()
+        // Pre-compute the global MediaFlow settings (checked once); whether it actually
+        // applies is decided per-channel below, since the proxy can be forced on for a
+        // single channel (or its source playlist) even when the playlist-level toggle is off.
+        $mediaFlowRewriteStreamUrls = PlaylistFacade::mediaFlowProxyEnabled()
             && (PlaylistFacade::getMediaFlowSettings()['mediaflow_proxy_rewrite_stream_urls'] ?? false);
 
         // Pre-compute the base URL for stream URL generation (used if proxy enabled or internal Xtream format used)
         $baseUrl = ProxyFacade::getBaseUrl();
         $useInternalXtreamFormat = ! ((config('app.disable_m3u_xtream_format') ?? false) || $playlist->disable_m3u_xtream_format);
 
-        return response()->stream(function () use ($cursor, $baseUrl, $username, $password, $playlist, $idChannelBy, $mfRewriteEnabled, $isCustomContext, $useInternalXtreamFormat, &$channelNumber) {
+        return response()->stream(function () use ($cursor, $baseUrl, $username, $password, $playlist, $idChannelBy, $proxyEnabled, $mediaFlowRewriteStreamUrls, $isCustomContext, $useInternalXtreamFormat, &$channelNumber) {
             $first = true;
             echo '[';
+            // Memoized by playlist_id so a batch of channels sharing the same source
+            // playlist (the common case) only resolves it once rather than per row.
+            $sourcePlaylistCache = [];
             foreach ($cursor as $channel) {
+                // Resolve the channel's own source playlist (may differ from the
+                // requested $playlist for merged/custom playlists/aliases) so we can
+                // check its proxy/output settings without an N+1 query per channel.
+                $sourcePlaylistId = $channel->playlist_id;
+                if ($sourcePlaylistId !== null) {
+                    if (! array_key_exists($sourcePlaylistId, $sourcePlaylistCache)) {
+                        $sourcePlaylistCache[$sourcePlaylistId] = Playlist::find($sourcePlaylistId, ['id', 'xtream', 'enable_proxy', 'profiles_enabled', 'xtream_config']);
+                    }
+                    $channelSourcePlaylist = $sourcePlaylistCache[$sourcePlaylistId];
+                } else {
+                    $channelSourcePlaylist = null;
+                }
+
+                // A channel can force the proxy path even when the playlist-level toggle
+                // is off: its own per-channel override, or its source playlist pooling
+                // provider profiles (profile selection/pool distribution only happens on
+                // the proxy path). Mirrors the `needsProxy` check in
+                // XtreamStreamController::handleLive()/handleVod().
+                $channelProxyEnabled = $playlist->user->canUseProxy()
+                    && ($proxyEnabled || $channel->enable_proxy || ($channelSourcePlaylist->profiles_enabled ?? false));
+                $channelMfRewriteEnabled = ! $channelProxyEnabled && $mediaFlowRewriteStreamUrls;
+
                 $url = PlaylistUrlService::getChannelUrl($channel, $playlist);
 
                 $channelNo = ($isCustomContext && ! empty($channel->pivot?->channel_number))
@@ -576,9 +636,8 @@ class PlaylistGenerateController extends Controller
                 $filename = parse_url($url, PHP_URL_PATH);
                 $extension = pathinfo($filename, PATHINFO_EXTENSION);
                 if (empty($extension)) {
-                    $sourcePlaylist = $channel->getEffectivePlaylist();
-                    if ($sourcePlaylist?->xtream) {
-                        $extension = $sourcePlaylist->xtream_config['output'] ?? 'ts'; // Default to 'ts' if not set
+                    if ($channelSourcePlaylist?->xtream) {
+                        $extension = $channelSourcePlaylist->xtream_config['output'] ?? 'ts'; // Default to 'ts' if not set
                     }
                 }
 
@@ -590,9 +649,17 @@ class PlaylistGenerateController extends Controller
                     if ($channel->is_vod) {
                         $urlPath = 'movie';
                         $extension = $channel->container_extension ?? 'mkv';
+                    } elseif ($channelProxyEnabled) {
+                        // The proxy may transcode the stream, so advertise the configured
+                        // output format instead of the raw provider extension - mirrors the
+                        // allowed_output_formats resolution in XtreamApiController::__invoke().
+                        $proxyOutput = $channelSourcePlaylist->xtream_config['output']
+                            ?? $playlist->xtream_config['output']
+                            ?? 'ts';
+                        $extension = $proxyOutput === 'hls' ? 'm3u8' : $proxyOutput;
                     }
                     $url = $baseUrl."/{$urlPath}/{$username}/{$password}/".$channel->id.'.'.$extension;
-                } elseif ($mfRewriteEnabled) {
+                } elseif ($channelMfRewriteEnabled) {
                     // Raw URL mode: wrap the provider URL through MediaFlow Proxy
                     $url = PlaylistFacade::buildMediaFlowStreamUrl($url);
                 }

--- a/app/Http/Controllers/PlaylistGenerateController.php
+++ b/app/Http/Controllers/PlaylistGenerateController.php
@@ -218,12 +218,8 @@ class PlaylistGenerateController extends Controller
                             $extension = $channel->container_extension ?? 'mkv';
                         } elseif ($channelProxyEnabled) {
                             // The proxy may transcode the stream, so advertise the configured
-                            // output format instead of the raw provider extension - mirrors the
-                            // allowed_output_formats resolution in XtreamApiController::__invoke().
-                            $proxyOutput = $channelSourcePlaylist->xtream_config['output']
-                                ?? $playlist->xtream_config['output']
-                                ?? 'ts';
-                            $extension = $proxyOutput === 'hls' ? 'm3u8' : $proxyOutput;
+                            // output format instead of the raw provider extension.
+                            $extension = self::resolveProxyOutputFormat($channelSourcePlaylist, $playlist);
                         }
                         $url = $baseUrl."/{$urlPath}/{$username}/{$password}/".$channel->id.'.'.$extension;
                     } elseif ($channelMfRewriteEnabled) {
@@ -623,12 +619,8 @@ class PlaylistGenerateController extends Controller
                         $extension = $channel->container_extension ?? 'mkv';
                     } elseif ($channelProxyEnabled) {
                         // The proxy may transcode the stream, so advertise the configured
-                        // output format instead of the raw provider extension - mirrors the
-                        // allowed_output_formats resolution in XtreamApiController::__invoke().
-                        $proxyOutput = $channelSourcePlaylist->xtream_config['output']
-                            ?? $playlist->xtream_config['output']
-                            ?? 'ts';
-                        $extension = $proxyOutput === 'hls' ? 'm3u8' : $proxyOutput;
+                        // output format instead of the raw provider extension.
+                        $extension = self::resolveProxyOutputFormat($channelSourcePlaylist, $playlist);
                     }
                     $url = $baseUrl."/{$urlPath}/{$username}/{$password}/".$channel->id.'.'.$extension;
                 } elseif ($channelMfRewriteEnabled) {
@@ -748,7 +740,7 @@ class PlaylistGenerateController extends Controller
         $sourcePlaylistId = $channel->playlist_id;
         if ($sourcePlaylistId !== null) {
             if (! array_key_exists($sourcePlaylistId, $sourcePlaylistCache)) {
-                $sourcePlaylistCache[$sourcePlaylistId] = Playlist::find($sourcePlaylistId, ['id', 'xtream', 'enable_proxy', 'profiles_enabled', 'xtream_config']);
+                $sourcePlaylistCache[$sourcePlaylistId] = Playlist::find($sourcePlaylistId, ['id', 'xtream', 'profiles_enabled', 'xtream_config']);
             }
             $channelSourcePlaylist = $sourcePlaylistCache[$sourcePlaylistId];
         } else {
@@ -759,6 +751,29 @@ class PlaylistGenerateController extends Controller
             && ($proxyEnabled || $channel->enable_proxy || ($channelSourcePlaylist->profiles_enabled ?? false));
 
         return [$channelSourcePlaylist, $channelProxyEnabled, ! $channelProxyEnabled && $mediaFlowRewriteStreamUrls];
+    }
+
+    /**
+     * Resolve the proxy's configured output format extension for a live channel,
+     * preferring the channel's own source playlist's xtream_config and falling back
+     * to the requested playlist's. A PlaylistAlias's own xtream_config is a
+     * normalized list of provider account configs (not a single keyed config), so
+     * its actual output setting must be read from the real playlist it wraps via
+     * getEffectivePlaylist() instead - mirrors the allowed_output_formats
+     * resolution in XtreamApiController::__invoke().
+     */
+    private static function resolveProxyOutputFormat(?Playlist $channelSourcePlaylist, $playlist): string
+    {
+        $proxyOutput = $channelSourcePlaylist?->xtream_config['output'] ?? null;
+
+        if ($proxyOutput === null) {
+            $contextXtreamConfig = $playlist instanceof PlaylistAlias
+                ? ($playlist->getEffectivePlaylist()?->xtream_config ?? null)
+                : ($playlist->xtream_config ?? null);
+            $proxyOutput = $contextXtreamConfig['output'] ?? 'ts';
+        }
+
+        return $proxyOutput === 'hls' ? 'm3u8' : $proxyOutput;
     }
 
     /**

--- a/app/Http/Controllers/PlaylistGenerateController.php
+++ b/app/Http/Controllers/PlaylistGenerateController.php
@@ -129,27 +129,13 @@ class PlaylistGenerateController extends Controller
                 // playlist (the common case) only resolves it once rather than per row.
                 $sourcePlaylistCache = [];
                 foreach ($cursor as $channel) {
-                    // Resolve the channel's own source playlist (may differ from the
-                    // requested $playlist for merged/custom playlists/aliases) so we can
-                    // check its proxy/output settings without an N+1 query per channel.
-                    $sourcePlaylistId = $channel->playlist_id;
-                    if ($sourcePlaylistId !== null) {
-                        if (! array_key_exists($sourcePlaylistId, $sourcePlaylistCache)) {
-                            $sourcePlaylistCache[$sourcePlaylistId] = Playlist::find($sourcePlaylistId, ['id', 'xtream', 'enable_proxy', 'profiles_enabled', 'xtream_config']);
-                        }
-                        $channelSourcePlaylist = $sourcePlaylistCache[$sourcePlaylistId];
-                    } else {
-                        $channelSourcePlaylist = null;
-                    }
-
-                    // A channel can force the proxy path even when the playlist-level toggle
-                    // is off: its own per-channel override, or its source playlist pooling
-                    // provider profiles (profile selection/pool distribution only happens on
-                    // the proxy path). Mirrors the `needsProxy` check in
-                    // XtreamStreamController::handleLive()/handleVod().
-                    $channelProxyEnabled = $playlist->user->canUseProxy()
-                        && ($proxyEnabled || $channel->enable_proxy || ($channelSourcePlaylist->profiles_enabled ?? false));
-                    $channelMfRewriteEnabled = ! $channelProxyEnabled && $mediaFlowRewriteStreamUrls;
+                    [$channelSourcePlaylist, $channelProxyEnabled, $channelMfRewriteEnabled] = self::resolveChannelProxyContext(
+                        $playlist,
+                        $channel,
+                        $proxyEnabled,
+                        $mediaFlowRewriteStreamUrls,
+                        $sourcePlaylistCache
+                    );
                     // Get the title and name
                     $title = $channel->title_custom ?? $channel->title;
                     $name = $channel->name_custom ?? $channel->name;
@@ -591,27 +577,13 @@ class PlaylistGenerateController extends Controller
             // playlist (the common case) only resolves it once rather than per row.
             $sourcePlaylistCache = [];
             foreach ($cursor as $channel) {
-                // Resolve the channel's own source playlist (may differ from the
-                // requested $playlist for merged/custom playlists/aliases) so we can
-                // check its proxy/output settings without an N+1 query per channel.
-                $sourcePlaylistId = $channel->playlist_id;
-                if ($sourcePlaylistId !== null) {
-                    if (! array_key_exists($sourcePlaylistId, $sourcePlaylistCache)) {
-                        $sourcePlaylistCache[$sourcePlaylistId] = Playlist::find($sourcePlaylistId, ['id', 'xtream', 'enable_proxy', 'profiles_enabled', 'xtream_config']);
-                    }
-                    $channelSourcePlaylist = $sourcePlaylistCache[$sourcePlaylistId];
-                } else {
-                    $channelSourcePlaylist = null;
-                }
-
-                // A channel can force the proxy path even when the playlist-level toggle
-                // is off: its own per-channel override, or its source playlist pooling
-                // provider profiles (profile selection/pool distribution only happens on
-                // the proxy path). Mirrors the `needsProxy` check in
-                // XtreamStreamController::handleLive()/handleVod().
-                $channelProxyEnabled = $playlist->user->canUseProxy()
-                    && ($proxyEnabled || $channel->enable_proxy || ($channelSourcePlaylist->profiles_enabled ?? false));
-                $channelMfRewriteEnabled = ! $channelProxyEnabled && $mediaFlowRewriteStreamUrls;
+                [$channelSourcePlaylist, $channelProxyEnabled, $channelMfRewriteEnabled] = self::resolveChannelProxyContext(
+                    $playlist,
+                    $channel,
+                    $proxyEnabled,
+                    $mediaFlowRewriteStreamUrls,
+                    $sourcePlaylistCache
+                );
 
                 $url = PlaylistUrlService::getChannelUrl($channel, $playlist);
 
@@ -749,6 +721,44 @@ class PlaylistGenerateController extends Controller
             'LineupURL' => $baseUrl.$authPath.'/lineup.json',
             'TunerCount' => $tunerCount,
         ];
+    }
+
+    /**
+     * Resolve a channel's proxy context: its own source playlist (memoized in
+     * $sourcePlaylistCache by playlist_id, so a batch of channels sharing the same
+     * source playlist only resolves it once instead of once per row), whether the
+     * proxy is effectively enabled for it, and whether MediaFlow's raw-URL rewrite
+     * applies.
+     *
+     * A channel can force the proxy path even when the playlist-level toggle is
+     * off: its own per-channel override, or its source playlist pooling provider
+     * profiles (profile selection/pool distribution only happens on the proxy
+     * path). Mirrors the `needsProxy` check in
+     * XtreamStreamController::handleLive()/handleVod().
+     *
+     * @return array{0: ?Playlist, 1: bool, 2: bool}
+     */
+    private static function resolveChannelProxyContext(
+        $playlist,
+        Channel $channel,
+        bool $proxyEnabled,
+        bool $mediaFlowRewriteStreamUrls,
+        array &$sourcePlaylistCache
+    ): array {
+        $sourcePlaylistId = $channel->playlist_id;
+        if ($sourcePlaylistId !== null) {
+            if (! array_key_exists($sourcePlaylistId, $sourcePlaylistCache)) {
+                $sourcePlaylistCache[$sourcePlaylistId] = Playlist::find($sourcePlaylistId, ['id', 'xtream', 'enable_proxy', 'profiles_enabled', 'xtream_config']);
+            }
+            $channelSourcePlaylist = $sourcePlaylistCache[$sourcePlaylistId];
+        } else {
+            $channelSourcePlaylist = null;
+        }
+
+        $channelProxyEnabled = $playlist->user->canUseProxy()
+            && ($proxyEnabled || $channel->enable_proxy || ($channelSourcePlaylist->profiles_enabled ?? false));
+
+        return [$channelSourcePlaylist, $channelProxyEnabled, ! $channelProxyEnabled && $mediaFlowRewriteStreamUrls];
     }
 
     /**

--- a/app/Http/Controllers/PlaylistGenerateController.php
+++ b/app/Http/Controllers/PlaylistGenerateController.php
@@ -228,6 +228,15 @@ class PlaylistGenerateController extends Controller
                     }
                     $url = rtrim($url, '.');
 
+                    // The catchup-source URL always points at our own timeshift endpoint when the
+                    // proxy is enabled, regardless of whether the main URL above used the internal
+                    // Xtream format, so its extension must independently reflect the proxy's
+                    // configured output format rather than reusing $extension (which is only
+                    // proxy-aware inside the $useInternalXtreamFormat branch).
+                    $catchupExtension = ($channelProxyEnabled && ! $channel->is_vod)
+                        ? self::resolveProxyOutputFormat($channelSourcePlaylist, $playlist)
+                        : $extension;
+
                     // Make sure TVG ID only contains characters and numbers
                     $tvgId = preg_replace(config('dev.tvgid.regex'), '', $tvgId);
 
@@ -246,7 +255,7 @@ class PlaylistGenerateController extends Controller
                         // This also ensures catchup works for Xtream-imported channels that have
                         // tv_archive=1 but no catchup_source URL template stored.
                         if (($channelProxyEnabled || $useInternalXtreamFormat) && $channel->catchup) {
-                            $catchupExt = $extension ?: 'ts';
+                            $catchupExt = $catchupExtension ?: 'ts';
                             $catchupSource = "{$baseUrl}/timeshift/{$username}/{$password}/{duration}/{start}/{$channel->id}.{$catchupExt}";
                             $extInf .= " catchup-source=\"{$catchupSource}\"";
                         } elseif ($channel->catchup_source) {
@@ -725,8 +734,8 @@ class PlaylistGenerateController extends Controller
      * A channel can force the proxy path even when the playlist-level toggle is
      * off: its own per-channel override, or its source playlist pooling provider
      * profiles (profile selection/pool distribution only happens on the proxy
-     * path). Mirrors the `needsProxy` check in
-     * XtreamStreamController::handleLive()/handleVod().
+     * path). Uses the same `Channel::needsProxy()` rule as
+     * XtreamStreamController::handleLive()/handleVod() so the two can't drift apart.
      *
      * @return array{0: ?Playlist, 1: bool, 2: bool}
      */
@@ -747,8 +756,13 @@ class PlaylistGenerateController extends Controller
             $channelSourcePlaylist = null;
         }
 
-        $channelProxyEnabled = $playlist->user->canUseProxy()
-            && ($proxyEnabled || $channel->enable_proxy || ($channelSourcePlaylist->profiles_enabled ?? false));
+        $channelProxyEnabled = Channel::needsProxy(
+            channelEnableProxy: (bool) $channel->enable_proxy,
+            playlistEnableProxy: $proxyEnabled,
+            requestProxyFlag: false,
+            sourcePlaylistProfilesEnabled: $channelSourcePlaylist->profiles_enabled ?? false,
+            userCanUseProxy: $playlist->user->canUseProxy(),
+        );
 
         return [$channelSourcePlaylist, $channelProxyEnabled, ! $channelProxyEnabled && $mediaFlowRewriteStreamUrls];
     }

--- a/app/Http/Controllers/XtreamStreamController.php
+++ b/app/Http/Controllers/XtreamStreamController.php
@@ -283,12 +283,15 @@ class XtreamStreamController extends Controller
             // must be taken even if enable_proxy is off on both the channel and the
             // (possibly merged/custom) playlist being streamed through - profile
             // selection and pool distribution only happen on the proxy path.
-            $needsProxy = $channel->enable_proxy
-                || $playlist->enable_proxy
-                || $request->input('proxy') === 'true'
-                || ($channel->playlist instanceof Playlist && $channel->playlist->profiles_enabled);
+            $needsProxy = Channel::needsProxy(
+                channelEnableProxy: (bool) $channel->enable_proxy,
+                playlistEnableProxy: (bool) $playlist->enable_proxy,
+                requestProxyFlag: $request->input('proxy') === 'true',
+                sourcePlaylistProfilesEnabled: $channel->playlist instanceof Playlist && $channel->playlist->profiles_enabled,
+                userCanUseProxy: $playlist->user->canUseProxy(),
+            );
 
-            if ($needsProxy && $playlist->user->canUseProxy()) {
+            if ($needsProxy) {
                 // Timeshift handled in proxy controller (if needed)
                 // Add username and PlaylistAuth ID to request for proxy traceability and per-auth enforcement
                 $request->merge(['username' => $username]);
@@ -343,12 +346,15 @@ class XtreamStreamController extends Controller
         if ($channel instanceof Channel) {
             // See handleLive(): pooled-provider playlists must use the proxy path so
             // profile selection and pool distribution are applied.
-            $needsProxy = $channel->enable_proxy
-                || $playlist->enable_proxy
-                || $request->input('proxy') === 'true'
-                || ($channel->playlist instanceof Playlist && $channel->playlist->profiles_enabled);
+            $needsProxy = Channel::needsProxy(
+                channelEnableProxy: (bool) $channel->enable_proxy,
+                playlistEnableProxy: (bool) $playlist->enable_proxy,
+                requestProxyFlag: $request->input('proxy') === 'true',
+                sourcePlaylistProfilesEnabled: $channel->playlist instanceof Playlist && $channel->playlist->profiles_enabled,
+                userCanUseProxy: $playlist->user->canUseProxy(),
+            );
 
-            if ($needsProxy && $playlist->user->canUseProxy()) {
+            if ($needsProxy) {
                 // Add username and PlaylistAuth ID to request for proxy traceability and per-auth enforcement
                 $request->merge(['username' => $username]);
                 if ($playlistAuth instanceof PlaylistAuth) {

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -137,6 +137,31 @@ class Channel extends Model
         return (bool) ($playlist?->enable_proxy ?? false);
     }
 
+    /**
+     * Shared proxy-eligibility rule used by both live streaming (XtreamStreamController)
+     * and static output generation (PlaylistGenerateController::generate*), so the two
+     * stay in sync instead of maintaining separate copies of the same rule.
+     *
+     * A channel is proxied when the user's plan allows it and any of: the channel itself
+     * force-enables the proxy, the playlist being streamed/output through has it enabled,
+     * the request explicitly asked for it, or the channel's own source playlist pools
+     * provider profiles (profile selection/pool distribution only happens on the proxy path).
+     */
+    public static function needsProxy(
+        bool $channelEnableProxy,
+        bool $playlistEnableProxy,
+        bool $requestProxyFlag,
+        bool $sourcePlaylistProfilesEnabled,
+        bool $userCanUseProxy
+    ): bool {
+        return $userCanUseProxy && (
+            $channelEnableProxy
+            || $playlistEnableProxy
+            || $requestProxyFlag
+            || $sourcePlaylistProfilesEnabled
+        );
+    }
+
     public function playlist(): BelongsTo
     {
         return $this->belongsTo(Playlist::class);

--- a/tests/Feature/PlaylistGenerateProxyFormatTest.php
+++ b/tests/Feature/PlaylistGenerateProxyFormatTest.php
@@ -8,12 +8,15 @@
  * hls -> m3u8), not just the raw provider extension.
  */
 
+use App\Http\Controllers\PlaylistGenerateController;
 use App\Models\Channel;
 use App\Models\Group;
 use App\Models\Playlist;
+use App\Models\PlaylistAlias;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
 
 uses(RefreshDatabase::class);
 
@@ -119,4 +122,57 @@ it('HDHR lineup does not force the proxy output format when neither the channel 
 
     expect($lineup)->toHaveCount(1)
         ->and($lineup[0]['URL'])->toContain("/live/{$this->user->name}/{$playlist->uuid}/{$channel->id}.ts");
+});
+
+it('forces the proxy path when the source playlist pools provider profiles, even without any enable_proxy toggle', function () {
+    $playlist = Playlist::factory()->for($this->user)->create([
+        'enable_proxy' => false,
+        'profiles_enabled' => true,
+        'xtream' => true,
+        'xtream_config' => ['output' => 'hls'],
+    ]);
+    $group = Group::factory()->for($playlist)->for($this->user)->create();
+
+    $channel = Channel::factory()->for($this->user)->for($playlist)->for($group)->create([
+        'enabled' => true,
+        'is_vod' => false,
+        'enable_proxy' => false,
+        'url' => 'http://provider.example.com/live/olduser/oldpass/1234',
+    ]);
+
+    $response = $this->get("/{$playlist->uuid}/playlist.m3u");
+
+    $response->assertStatus(200);
+    $username = urlencode($this->user->name);
+    $password = urlencode($playlist->uuid);
+    expect($response->streamedContent())
+        ->toContain("/live/{$username}/{$password}/{$channel->id}.m3u8");
+});
+
+it('resolves the proxy output format for a PlaylistAlias via its wrapped playlist, not the alias own xtream_config list', function () {
+    $wrapped = Playlist::factory()->for($this->user)->create([
+        'xtream' => true,
+        'xtream_config' => ['output' => 'hls'],
+    ]);
+
+    $alias = PlaylistAlias::create([
+        'playlist_id' => $wrapped->id,
+        'user_id' => $this->user->id,
+        'name' => 'Test Alias',
+        'uuid' => Str::uuid()->toString(),
+        // The alias's own xtream_config is a normalized LIST of provider account
+        // configs (url/username/password), never a keyed config with an 'output'
+        // key - reading ['output'] directly off it must not be how the format
+        // is resolved, or it silently falls back to 'ts'.
+        'xtream_config' => [[
+            'url' => 'http://provider.example.com:8080',
+            'username' => 'aliasuser',
+            'password' => 'aliaspass',
+        ]],
+    ]);
+
+    $method = new ReflectionMethod(PlaylistGenerateController::class, 'resolveProxyOutputFormat');
+    $method->setAccessible(true);
+
+    expect($method->invoke(null, null, $alias))->toBe('m3u8');
 });

--- a/tests/Feature/PlaylistGenerateProxyFormatTest.php
+++ b/tests/Feature/PlaylistGenerateProxyFormatTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * The M3U playlist generator (PlaylistGenerateController) must mirror the Xtream API's
+ * proxy-awareness: a channel can force the proxy path via its own `enable_proxy` toggle
+ * even when the playlist-level toggle is off, and when the proxy is in play the output
+ * URL's extension should reflect the playlist's configured proxy output format (mapped
+ * hls -> m3u8), not just the raw provider extension.
+ */
+
+use App\Models\Channel;
+use App\Models\Group;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+
+    $this->user = User::factory()->create([
+        'permissions' => ['use_proxy'],
+    ]);
+});
+
+it('uses the channel-level proxy override and the playlist output format even when playlist-level proxy is off', function () {
+    $playlist = Playlist::factory()->for($this->user)->create([
+        'enable_proxy' => false,
+        'xtream' => true,
+        'xtream_config' => ['output' => 'hls'],
+    ]);
+    $group = Group::factory()->for($playlist)->for($this->user)->create();
+
+    $channel = Channel::factory()->for($this->user)->for($playlist)->for($group)->create([
+        'enabled' => true,
+        'is_vod' => false,
+        'enable_proxy' => true,
+        'url' => 'http://provider.example.com/live/olduser/oldpass/1234',
+    ]);
+
+    $response = $this->get("/{$playlist->uuid}/playlist.m3u");
+
+    $response->assertStatus(200);
+    $username = urlencode($this->user->name);
+    $password = urlencode($playlist->uuid);
+    expect($response->streamedContent())
+        ->toContain("/live/{$username}/{$password}/{$channel->id}.m3u8");
+});
+
+it('does not force the proxy output format when neither the channel nor the playlist has proxy enabled', function () {
+    $playlist = Playlist::factory()->for($this->user)->create([
+        'enable_proxy' => false,
+        'xtream' => true,
+        'xtream_config' => ['output' => 'hls'],
+    ]);
+    $group = Group::factory()->for($playlist)->for($this->user)->create();
+
+    $channel = Channel::factory()->for($this->user)->for($playlist)->for($group)->create([
+        'enabled' => true,
+        'is_vod' => false,
+        'enable_proxy' => false,
+        'url' => 'http://provider.example.com/live/olduser/oldpass/1234.ts',
+    ]);
+
+    $response = $this->get("/{$playlist->uuid}/playlist.m3u");
+
+    $response->assertStatus(200);
+    $username = urlencode($this->user->name);
+    $password = urlencode($playlist->uuid);
+    expect($response->streamedContent())
+        ->toContain("/live/{$username}/{$password}/{$channel->id}.ts");
+});
+
+it('HDHR lineup uses the channel-level proxy override and the playlist output format even when playlist-level proxy is off', function () {
+    $playlist = Playlist::factory()->for($this->user)->create([
+        'enable_proxy' => false,
+        'xtream' => true,
+        'xtream_config' => ['output' => 'hls'],
+    ]);
+    $group = Group::factory()->for($playlist)->for($this->user)->create();
+
+    $channel = Channel::factory()->for($this->user)->for($playlist)->for($group)->create([
+        'enabled' => true,
+        'is_vod' => false,
+        'enable_proxy' => true,
+        'url' => 'http://provider.example.com/live/olduser/oldpass/1234',
+    ]);
+
+    $response = $this->get("/{$playlist->uuid}/hdhr/lineup.json");
+
+    $response->assertStatus(200);
+    $lineup = json_decode($response->streamedContent(), true);
+
+    expect($lineup)->toHaveCount(1)
+        ->and($lineup[0]['URL'])->toContain("/live/{$this->user->name}/{$playlist->uuid}/{$channel->id}.m3u8");
+});
+
+it('HDHR lineup does not force the proxy output format when neither the channel nor the playlist has proxy enabled', function () {
+    $playlist = Playlist::factory()->for($this->user)->create([
+        'enable_proxy' => false,
+        'xtream' => true,
+        'xtream_config' => ['output' => 'hls'],
+    ]);
+    $group = Group::factory()->for($playlist)->for($this->user)->create();
+
+    $channel = Channel::factory()->for($this->user)->for($playlist)->for($group)->create([
+        'enabled' => true,
+        'is_vod' => false,
+        'enable_proxy' => false,
+        'url' => 'http://provider.example.com/live/olduser/oldpass/1234.ts',
+    ]);
+
+    $response = $this->get("/{$playlist->uuid}/hdhr/lineup.json");
+
+    $response->assertStatus(200);
+    $lineup = json_decode($response->streamedContent(), true);
+
+    expect($lineup)->toHaveCount(1)
+        ->and($lineup[0]['URL'])->toContain("/live/{$this->user->name}/{$playlist->uuid}/{$channel->id}.ts");
+});

--- a/tests/Feature/PlaylistGenerateProxyFormatTest.php
+++ b/tests/Feature/PlaylistGenerateProxyFormatTest.php
@@ -149,6 +149,32 @@ it('forces the proxy path when the source playlist pools provider profiles, even
         ->toContain("/live/{$username}/{$password}/{$channel->id}.m3u8");
 });
 
+it('uses the proxy output format for the catchup-source extension even when the internal Xtream format is disabled', function () {
+    $playlist = Playlist::factory()->for($this->user)->create([
+        'enable_proxy' => false,
+        'disable_m3u_xtream_format' => true,
+        'xtream' => true,
+        'xtream_config' => ['output' => 'hls'],
+    ]);
+    $group = Group::factory()->for($playlist)->for($this->user)->create();
+
+    $channel = Channel::factory()->for($this->user)->for($playlist)->for($group)->create([
+        'enabled' => true,
+        'is_vod' => false,
+        'enable_proxy' => true,
+        'catchup' => 'default',
+        'url' => 'http://provider.example.com/live/olduser/oldpass/1234.ts',
+    ]);
+
+    $response = $this->get("/{$playlist->uuid}/playlist.m3u");
+
+    $response->assertStatus(200);
+    $username = urlencode($this->user->name);
+    $password = urlencode($playlist->uuid);
+    expect($response->streamedContent())
+        ->toContain("/timeshift/{$username}/{$password}/{duration}/{start}/{$channel->id}.m3u8");
+});
+
 it('resolves the proxy output format for a PlaylistAlias via its wrapped playlist, not the alias own xtream_config list', function () {
     $wrapped = Playlist::factory()->for($this->user)->create([
         'xtream' => true,


### PR DESCRIPTION
Use proxy format when enabled for the playlist or channel to reflect how it's handled in XAPI already.